### PR TITLE
Fix login credential validation

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/controller/EmpleadoController.java
+++ b/src/main/java/com/kathsoft/kathpos/app/controller/EmpleadoController.java
@@ -48,34 +48,46 @@ public class EmpleadoController implements Serializable {
 	 *                 empleado; }
 	 */
 	/**
-	 * metodo para validar el ingreso al sistema, hace uso de un procedimiento
-	 * almacenado para validar si el usuario existe y sis sus credenciales de acceso
-	 * son correctas
-	 * 
-	 * @return {@code false} si el server arroja un error
-	 * @return {@code true} si el server no arroja nada
+	 * Metodo para validar el ingreso al sistema.
+	 * <p>
+	 * El acceso solo es valido cuando el procedimiento almacenado retorna una fila
+	 * con un resultado significativo. Si no hay fila, si el resultado viene vacio,
+	 * o si el resultado representa un valor falso, el acceso se rechaza.
+	 *
+	 * @param empl empleado con nombre corto y contrasenia capturados desde la vista
+	 * @return {@code true} si las credenciales son validas; {@code false} en caso contrario
 	 */
 	public boolean validarIngreso(Empleado empl) {
 
 		CallableStatement stm = null;
 		ResultSet rset = null;
 
-		String pswd = "";		
+		if (empl == null || empl.getNombreCorto() == null || empl.getNombreCorto().isBlank()
+				|| empl.getPassword() == null || empl.getPassword().isBlank()) {
+			return false;
+		}
 
 		try {
 
-			cn = Conexion.establecerConexionLocal("kath_erp");
+			cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
 			stm = cn.prepareCall("CALL validar_entrada(?,?)");
 			stm.setString(1, empl.getNombreCorto());
 			stm.setString(2, empl.getPassword());
 			rset = stm.executeQuery();
 
-			if (rset.next()) {
-				pswd = rset.getString(1);
-				System.out.println(pswd);
+			if (!rset.next()) {
+				return false;
 			}
-			
-			return true;
+
+			String resultado = rset.getString(1);
+
+			if (resultado == null) {
+				return false;
+			}
+
+			resultado = resultado.trim();
+
+			return !resultado.isEmpty() && !"0".equals(resultado) && !"false".equalsIgnoreCase(resultado);
 
 		} catch (SQLException er) {
 			er.printStackTrace();

--- a/src/main/java/com/kathsoft/kathpos/app/view/Fr_LogIn.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/Fr_LogIn.java
@@ -26,8 +26,6 @@ import javax.swing.JPasswordField;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.LineBorder;
 
-import com.kathsoft.kathpos.app.controller.EmpleadoController;
-import com.kathsoft.kathpos.app.controller.SucursalController;
 import com.kathsoft.kathpos.app.model.Empleado;
 import com.kathsoft.kathpos.app.model.Sucursal;
 import com.kathsoft.kathpos.tools.AppContext;
@@ -256,38 +254,44 @@ public class Fr_LogIn extends JFrame {
 	}
 	
 	/**
-	 * validación de credeciales de acceso y entrada al sistema
+	 * Validacion de credenciales de acceso y entrada al sistema.
 	 */
 	private void logIngFrPrincipal() {
-		
-		String contra = "";
-		char[] pswdCaracteres = this.pswfContrasenia.getPassword();
-		
-		for(char c: pswdCaracteres) {
-			contra = contra + c;
+
+		Object usuarioSeleccionado = this.jcmbUsuarios.getSelectedItem();
+
+		if (usuarioSeleccionado == null) {
+			JOptionPane.showMessageDialog(this, "Debe seleccionar un usuario", "Error", JOptionPane.ERROR_MESSAGE);
+			return;
 		}
-		
-		empl.setNombreCorto(this.jcmbUsuarios.getSelectedItem().toString());
-		empl.setPassword(contra);			
-		
-		if (AppContext.empleadoController.validarIngreso(empl) == false || contra.isEmpty()) {
-			
-			JOptionPane.showMessageDialog(this, "Error de acceso", "Error", JOptionPane.ERROR_MESSAGE);
-			
-		} else {
-			EventQueue.invokeLater(new Runnable() {
-				public void run() {
-					try {
-						Fr_principal frame = new Fr_principal(sucursal);
-						frame.setVisible(true);
-					} catch (Exception e) {
-						e.printStackTrace();
-					}
+
+		String contra = String.valueOf(this.pswfContrasenia.getPassword());
+
+		if (contra.isBlank()) {
+			JOptionPane.showMessageDialog(this, "Debe capturar la contraseña", "Error", JOptionPane.ERROR_MESSAGE);
+			return;
+		}
+
+		empl.setNombreCorto(usuarioSeleccionado.toString());
+		empl.setPassword(contra);
+
+		if (!AppContext.empleadoController.validarIngreso(empl)) {
+			JOptionPane.showMessageDialog(this, "Usuario o contraseña incorrectos", "Error", JOptionPane.ERROR_MESSAGE);
+			return;
+		}
+
+		EventQueue.invokeLater(new Runnable() {
+			public void run() {
+				try {
+					Fr_principal frame = new Fr_principal(sucursal);
+					frame.setVisible(true);
+				} catch (Exception e) {
+					e.printStackTrace();
 				}
-			});
-			
-			this.dispose();
-		}
+			}
+		});
+
+		this.dispose();
 	}
 	
 	/**


### PR DESCRIPTION
## Summary

Fixes the first critical security task from the correction plan: login validation.

## Changes

- Updates `EmpleadoController.validarIngreso(...)` so it no longer returns `true` simply because no SQL exception occurred.
- Rejects null or blank username/password values before querying the database.
- Interprets an empty result, `null`, `0`, or `false` from `validar_entrada(?, ?)` as invalid credentials.
- Removes console printing of the value returned by the login procedure.
- Hardens `Fr_LogIn.logIngFrPrincipal()` so the form validates selected user and password before attempting login.
- Shows a clear error message when credentials are invalid.

## Manual test checklist

- [ ] Empty password does not open `Fr_principal`.
- [ ] No selected user does not open `Fr_principal`.
- [ ] Incorrect password does not open `Fr_principal`.
- [ ] Correct credentials open `Fr_principal`.

## Important note

This fix assumes the stored procedure `validar_entrada(?, ?)` returns a meaningful successful value only when credentials are valid. The safest database contract is to return `1` for valid credentials and `0` or no row for invalid credentials.