### PR TITLE
Externalize database connection configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,18 @@
-#archivos a los que no se les dará seguimiento
-#
-#archivos txt y de seguimiento
+# archivos a los que no se les dará seguimiento
 
-*.txt
-
-#ficheros generados por vim
-#
-.gitignore~
+# ficheros de texto y respaldo
 *.txt
 *.txt~
+.gitignore~
 *.gitignore.un~
+
+# artefactos generados por Maven
 /target/
+
+# configuracion local y secretos
+config/database.properties
+.env
+*.env
+
+# logs
+*.log

--- a/config/database.properties.example
+++ b/config/database.properties.example
@@ -1,0 +1,13 @@
+# Copie este archivo como:
+# config/database.properties
+#
+# No suba config/database.properties al repositorio.
+# Tambien puede configurar estos valores mediante variables de entorno:
+# KATH_DB_HOST, KATH_DB_PORT, KATH_DB_NAME, KATH_DB_USER, KATH_DB_PASSWORD, KATH_DB_PARAMS
+
+db.host=localhost
+db.port=3306
+db.name=kath_erp
+db.user=kath_app_user
+db.password=change-me
+db.params=serverTimezone=UTC

--- a/src/main/java/com/kathsoft/kathpos/tools/Conexion.java
+++ b/src/main/java/com/kathsoft/kathpos/tools/Conexion.java
@@ -1,18 +1,27 @@
 package com.kathsoft.kathpos.tools;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Properties;
 
 import javax.swing.JOptionPane;
 
 public class Conexion {
-	
-	public static final String DATA_BASE = "kath_erp";
-	
+
+	private static final String CONFIG_FILE_PATH = "config/database.properties";
+	private static final Properties DATABASE_PROPERTIES = cargarPropiedadesConexion();
+
+	public static final String DATA_BASE = obtenerValorConfiguracion("KATH_DB_NAME", "db.name", "kath_erp");
+
 	/**
 	 * bloque estatico para carga del controlador al momento de instanciar la clase
 	 */
@@ -30,17 +39,76 @@ public class Conexion {
 	}
 
 	/**
-	 * establece la conexión al servidor de la base de datos que se le pase como
-	 * argumento
-	 * 
-	 * @param nombreBBDD
-	 * @return
-	 * @throws SQLException
+	 * Establece la conexion al servidor de base de datos usando configuracion externa.
+	 * <p>
+	 * La configuracion puede venir de variables de entorno o del archivo local
+	 * {@code config/database.properties}. Las variables de entorno tienen prioridad
+	 * sobre el archivo de propiedades.
+	 *
+	 * @param nombreBBDD nombre de la base de datos a utilizar; si viene vacio se usa
+	 *                   la base configurada por defecto
+	 * @return conexion JDBC activa
+	 * @throws SQLException si falta configuracion obligatoria o si falla la conexion
 	 */
 	public static Connection establecerConexionLocal(String nombreBBDD) throws SQLException {
-		final String url = "jdbc:mysql://localhost:3306/" + nombreBBDD;
-		final String user = "root";
-		return DriverManager.getConnection(url, user, "2428");
+		String database = nombreBBDD == null || nombreBBDD.isBlank() ? DATA_BASE : nombreBBDD;
+		String host = obtenerValorConfiguracion("KATH_DB_HOST", "db.host", "localhost");
+		String port = obtenerValorConfiguracion("KATH_DB_PORT", "db.port", "3306");
+		String params = obtenerValorConfiguracion("KATH_DB_PARAMS", "db.params", "serverTimezone=UTC");
+		String user = obtenerValorConfiguracionObligatoria("KATH_DB_USER", "db.user");
+		String password = obtenerValorConfiguracionObligatoria("KATH_DB_PASSWORD", "db.password");
+
+		String url = "jdbc:mysql://" + host + ":" + port + "/" + database;
+
+		if (!params.isBlank()) {
+			url += "?" + params;
+		}
+
+		return DriverManager.getConnection(url, user, password);
+	}
+
+	private static Properties cargarPropiedadesConexion() {
+		Properties properties = new Properties();
+		Path configPath = Paths.get(CONFIG_FILE_PATH);
+
+		if (!Files.exists(configPath)) {
+			return properties;
+		}
+
+		try (InputStream input = Files.newInputStream(configPath)) {
+			properties.load(input);
+		} catch (IOException er) {
+			er.printStackTrace();
+		}
+
+		return properties;
+	}
+
+	private static String obtenerValorConfiguracion(String envName, String propertyName, String defaultValue) {
+		String envValue = System.getenv(envName);
+
+		if (envValue != null && !envValue.isBlank()) {
+			return envValue.trim();
+		}
+
+		String propertyValue = DATABASE_PROPERTIES.getProperty(propertyName);
+
+		if (propertyValue != null && !propertyValue.isBlank()) {
+			return propertyValue.trim();
+		}
+
+		return defaultValue;
+	}
+
+	private static String obtenerValorConfiguracionObligatoria(String envName, String propertyName) throws SQLException {
+		String value = obtenerValorConfiguracion(envName, propertyName, null);
+
+		if (value == null || value.isBlank()) {
+			throw new SQLException("Configuracion de base de datos faltante: defina " + envName + " o " + propertyName
+					+ " en " + CONFIG_FILE_PATH);
+		}
+
+		return value;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes Task 2 from the correction plan: remove hardcoded database credentials from the Java source code.

## Changes

- Removes hardcoded `root` user and hardcoded database password from `Conexion.java`.
- Loads database configuration from environment variables or `config/database.properties`.
- Environment variables have priority over the local properties file.
- Keeps safe defaults for host, port, database name, and JDBC params.
- Requires database user and password to be provided externally.
- Adds `config/database.properties.example` as a template.
- Updates `.gitignore` so the real `config/database.properties` file is not committed.

## Supported configuration

Environment variables:

- `KATH_DB_HOST`
- `KATH_DB_PORT`
- `KATH_DB_NAME`
- `KATH_DB_USER`
- `KATH_DB_PASSWORD`
- `KATH_DB_PARAMS`

Local file:

- `config/database.properties`

## Manual test checklist

- [ ] Copy `config/database.properties.example` to `config/database.properties`.
- [ ] Set real local credentials in `config/database.properties`.
- [ ] Run the application and verify login/database access still works.
- [ ] Delete or rename `config/database.properties` and verify the app fails with a clear missing-configuration message.
- [ ] Confirm no real database password is tracked by Git.

## Notes

This PR does not yet remove `static Connection` or refactor the JDBC layer. Those are separate tasks in the correction plan.