### PR TITLE
Fix | Flujo insert y update en modulo empleados

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/controller/EmpleadoController.java
+++ b/src/main/java/com/kathsoft/kathpos/app/controller/EmpleadoController.java
@@ -298,7 +298,7 @@ public class EmpleadoController implements Serializable {
 		ResultSet rset = null;
 		try {
 			cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
-			stm = cn.prepareCall("CALL insert_empleado(?,?,?,?,?,?,?,?,?,?,?,?,?,?)");
+			stm = cn.prepareCall("CALL insert_empleado(?,?,?,?,?,?,?,?,?,?,?,?,?)");
 			stm.setInt(1, empl.getIdCuentaContable());
 			stm.setInt(2, empl.getIdSucursal());
 			stm.setString(3, empl.getRfc());

--- a/src/main/java/com/kathsoft/kathpos/app/view/empleados/Fr_DatosEmpleado.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/empleados/Fr_DatosEmpleado.java
@@ -428,6 +428,7 @@ public class Fr_DatosEmpleado extends JFrame {
 	 * @param idEmpleado
 	 */
 	private void consultarEmpleadoPorId(int idEmpleado) {
+		
 		EmpleadoById empleado = AppContext.empleadoController.consultarEmpleadoPorId(idEmpleado);
 
 		if (empleado == null) {
@@ -447,9 +448,10 @@ public class Fr_DatosEmpleado extends JFrame {
 		txfCiudadEmpleado.setText(empleado.getCiudad());
 		textAreaDireccionEmpleado.setText(empleado.getDireccion());
 		txfCodigoPostal.setText(empleado.getCodigoPostal());
-		txfClaveCuentaContable.setText(String.valueOf(empleado.getIdCuentaContable()));
+		txfClaveCuentaContable.setText(empleado.getClaveCuentaContable());		
 		passwordFieldContraseniaEmpleado.setText("");
 		passwordFieldVerificarContraseniaEmpleado.setText("");
+		this.cuentaContable = new CuentaContableResponseViewModel(empleado.getIdCuentaContable(), empleado.getClaveCuentaContable());
 		UiTools.jComboboxSetSelectedIndex(this.cmbSucursalEmpleado, empleado.getIdSucursal());
 		
 	}
@@ -494,13 +496,14 @@ public class Fr_DatosEmpleado extends JFrame {
 	 * actualiza un registro existente de un empleado en la base de datos
 	 */
 	private void actualizarEmpleado(int idEmpleado) {
+		
 		if (!validarCamposVacios()) {
 			return;
 		}
 
 		Empleado empleado = new Empleado();
 		empleado.setIdEmpleado(idEmpleado);
-		empleado.setIdCuentaContable(Integer.parseInt(txfClaveCuentaContable.getText().trim()));
+		empleado.setIdCuentaContable(this.cuentaContable.idCuentaContable());
 		empleado.setIdSucursal(((JComboboxDataViewModel) cmbSucursalEmpleado.getSelectedItem()).id());
 		empleado.setRfc(txfRfcEmpleado.getText().trim());
 		empleado.setCurp(txfCurpEmpleado.getText().trim());
@@ -534,8 +537,8 @@ public class Fr_DatosEmpleado extends JFrame {
 				&& !frmtxfCorreoElectronico.getText().trim().isEmpty() && !txfEstadoEmpleado.getText().trim().isEmpty()
 				&& !txfCiudadEmpleado.getText().trim().isEmpty() && !textAreaDireccionEmpleado.getText().trim().isEmpty()
 				&& !txfCodigoPostal.getText().trim().isEmpty() && !txfClaveCuentaContable.getText().trim().isEmpty()
-				&& cmbSucursalEmpleado.getSelectedItem() != null && passwordFieldContraseniaEmpleado.getPassword().length > 0
-				&& passwordFieldVerificarContraseniaEmpleado.getPassword().length > 0;
+				&& cmbSucursalEmpleado.getSelectedItem() != null;
+				
 	}
 
 	private void llenarCmbSucursales() {

--- a/src/main/java/com/kathsoft/kathpos/app/view/empleados/PanelEmpleados.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/empleados/PanelEmpleados.java
@@ -29,6 +29,7 @@ import com.kathsoft.kathpos.tools.MessageHandler;
 import javax.swing.GroupLayout;
 import javax.swing.GroupLayout.Alignment;
 import javax.swing.LayoutStyle.ComponentPlacement;
+import javax.swing.ScrollPaneConstants;
 
 public class PanelEmpleados extends JPanel {
 


### PR DESCRIPTION
# Principales cambios efectuados:
- Se corrige la cantidad de parámetros pasados al procedimiento almacenado `insert_empleado` de 14 a 13 que son los correctos
- El campo clave cuenta contable rescata la clave de la cuenta contable y el Id de la cuenta en otro objeto que funciona como DTO
- La contraseña del empleado es un campo opcional al momento de actualizar los datos. si el empleado no modifica su contraseña el campo debe ir vacio.

## Que resuelve:

- El programa se rompia especialmente al modificar los datos de un empleado ya que desde el controlador se indicaban 14 parametros del procedimiento almacenado. algo incorrecto ya que solo 13 están definidos.