### PR TITLE
Refact | Modificación en respuesta obtenida en métodos crud

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/controller/TipoClienteController.java
+++ b/src/main/java/com/kathsoft/kathpos/app/controller/TipoClienteController.java
@@ -7,7 +7,9 @@ import java.sql.SQLException;
 import java.util.Vector;
 
 import com.kathsoft.kathpos.app.model.cliente.TipoCliente;
+import com.kathsoft.kathpos.app.model.viewmodel.SpResponseModel;
 import com.kathsoft.kathpos.tools.Conexion;
+import com.mysql.cj.protocol.Resultset;
 
 public class TipoClienteController {
 
@@ -85,9 +87,10 @@ public class TipoClienteController {
 
 	}
 
-	public void insertarNuevoTipoCliente(TipoCliente data) {
+	public SpResponseModel insertarNuevoTipoCliente(TipoCliente data) {
 
 		CallableStatement stm = null;
+		ResultSet rset = null;
 
 		try {
 
@@ -95,13 +98,20 @@ public class TipoClienteController {
 			stm = cn.prepareCall("CALL insert_nuevo_tipoCliente(?,?)");
 			stm.setString(1, data.getNombre());
 			stm.setString(2, data.getDescripcion());
-
-			stm.execute();
-
+			rset = stm.executeQuery();
+			
+			if(rset.next()) {
+				return new SpResponseModel(rset.getInt("id"), rset.getString("message"));
+			}
+			
+			return new SpResponseModel(500,"Ocurrio un error desconocido");
+			
 		} catch (SQLException er) {
 			er.printStackTrace();
+			return new SpResponseModel(500,er.getMessage());
 		} catch (Exception er) {
 			er.printStackTrace();
+			return new SpResponseModel(500,er.getMessage());
 		} finally {
 			try {
 				Conexion.cerrarConexion(cn, stm);
@@ -112,9 +122,10 @@ public class TipoClienteController {
 
 	}
 
-	public void actualizarTipoCliente(TipoCliente data) {
+	public SpResponseModel actualizarTipoCliente(TipoCliente data) {
 
 		CallableStatement stm = null;
+		ResultSet rset = null;
 
 		System.out.println(data.printData());
 
@@ -125,12 +136,20 @@ public class TipoClienteController {
 			stm.setInt(1, data.getIdTipoCliente());
 			stm.setString(2, data.getNombre());
 			stm.setString(3, data.getDescripcion());
-			stm.execute();
+			rset = stm.executeQuery();
+			
+			if(rset.next()) {
+				return new SpResponseModel(rset.getInt("id"), rset.getString("message"));
+			}
+			
+			return new SpResponseModel(500,"Ocurrio un error desconocido");
 
 		} catch (SQLException er) {
 			er.printStackTrace();
+			return new SpResponseModel(500,er.getMessage());
 		} catch (Exception er) {
 			er.printStackTrace();
+			return new SpResponseModel(500,er.getMessage());
 		} finally {
 			try {
 				Conexion.cerrarConexion(cn, stm);
@@ -177,14 +196,38 @@ public class TipoClienteController {
 		}
 	}
 	
-	public void eliminarTipoCliente(int idTipoCliente) throws SQLException{
-						
-		cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
-		var stm = cn.prepareCall("CALL eliminar_tipoCliente(?)");
-		stm.setInt(1, idTipoCliente);
-		stm.execute();
+	public SpResponseModel eliminarTipoCliente(int idTipoCliente) {
+			
+		ResultSet rset = null;
+		CallableStatement stm = null;
 		
-		Conexion.cerrarConexion(cn, stm);
+		try {
+			
+			cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
+			stm = cn.prepareCall("CALL eliminar_tipoCliente(?)");
+			stm.setInt(1, idTipoCliente);
+			rset = stm.executeQuery();
+			
+			if(rset.next()) {
+				return new SpResponseModel(rset.getInt("id"), rset.getString("message"));
+			}
+			
+			return new SpResponseModel(500,"Ocurrio un error desconocido");
+			
+		} catch (SQLException e) {
+			e.printStackTrace();
+			return new SpResponseModel(500,e.getMessage());
+		}finally {
+			try {
+				
+				Conexion.cerrarConexion(cn, rset, stm);
+				
+			} catch (Exception er) {
+				
+				er.printStackTrace();
+				
+			}
+		}		
 		
 	}
 	

--- a/src/main/java/com/kathsoft/kathpos/app/view/clientes/Fr_DatosTipoCliente.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/clientes/Fr_DatosTipoCliente.java
@@ -6,6 +6,8 @@ import javax.swing.border.EmptyBorder;
 
 import com.kathsoft.kathpos.app.controller.TipoClienteController;
 import com.kathsoft.kathpos.app.model.cliente.TipoCliente;
+import com.kathsoft.kathpos.tools.AppContext;
+import com.kathsoft.kathpos.tools.DataTools;
 import com.kathsoft.kathpos.tools.MessageHandler;
 
 import java.awt.BorderLayout;
@@ -152,7 +154,7 @@ public class Fr_DatosTipoCliente extends JFrame {
 				Fr_DatosTipoCliente.class.getResource("/com/kathsoft/kathpos/app/assets/nwCancel.png")));
 		panelInferiorBotones.add(btnCancelar);
 
-		btnAgregar = new JButton("Agregar");
+		btnAgregar = new JButton("Guardar");
 		btnAgregar.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent e) {
 				if (tipoOperacion == 1) {
@@ -185,9 +187,11 @@ public class Fr_DatosTipoCliente extends JFrame {
 		data.setNombre(this.txfNombre.getText());
 		data.setDescripcion(this.txfDescripcion.getText());
 
-		this.tipoClienteController.insertarNuevoTipoCliente(data);
+		var result = AppContext.tipoClienteController.insertarNuevoTipoCliente(data);
 
-		MessageHandler.displayMessage(MessageHandler.INSERT_SUCCESS_MESSAGE, this, "");
+		MessageHandler.displayMessage(
+				result.id() == 200 ?
+				MessageHandler.INSERT_SUCCESS_MESSAGE : MessageHandler.ERROR_MESSAGE, this, result.message());
 		
 		this.limpiarCampos();
 
@@ -220,11 +224,14 @@ public class Fr_DatosTipoCliente extends JFrame {
 		data.setNombre(this.txfNombre.getText());
 		data.setDescripcion(this.txfDescripcion.getText());
 
-		this.tipoClienteController.actualizarTipoCliente(data);
+		var result = AppContext.tipoClienteController.actualizarTipoCliente(data);
 
-		MessageHandler.displayMessage(MessageHandler.UPDATE_SUCCESS_MESSAGE, this, "");
+		MessageHandler.displayMessage(
+				result.id() == 200 ?
+				MessageHandler.UPDATE_SUCCESS_MESSAGE : MessageHandler.ERROR_MESSAGE, this, result.message());
 
 	}
+		
 
 	private boolean validarCamposVacios() {
 		return this.txfNombre.getText().isBlank() || this.txfDescripcion.getText().isBlank() ? true : false;

--- a/src/main/java/com/kathsoft/kathpos/app/view/clientes/PanelTipoCliente.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/clientes/PanelTipoCliente.java
@@ -1,6 +1,5 @@
 package com.kathsoft.kathpos.app.view.clientes;
 
-import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Container;
@@ -11,7 +10,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.sql.SQLException;
 
-import javax.swing.Box;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -19,14 +17,12 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
-import javax.swing.border.EmptyBorder;
 import javax.swing.table.DefaultTableModel;
 
-import com.kathsoft.kathpos.app.view.Fr_principal;
 import com.kathsoft.kathpos.tools.AppContext;
-import com.kathsoft.kathpos.tools.ConstantsConllections;
 import com.kathsoft.kathpos.tools.DataTools;
 import com.kathsoft.kathpos.tools.MessageHandler;
+
 import javax.swing.GroupLayout;
 import javax.swing.GroupLayout.Alignment;
 import javax.swing.LayoutStyle.ComponentPlacement;
@@ -35,7 +31,7 @@ public class PanelTipoCliente extends JPanel {
 
 	private static final long serialVersionUID = 1L;
 	private JPanel panelEtiquetaTipoCliente;
-	private Container panelTipoCliente;
+	//private Container panelTipoCliente;
 	private JLabel lblNewLabel_11;
 	private DefaultTableModel modelTablaTipoCliente;
 	private JPanel panelInferiorBusqueda;
@@ -130,16 +126,37 @@ public class PanelTipoCliente extends JPanel {
 		scrollPaneTableTipoCliente.setViewportView(tableTipoCliente);
 		
 		btnAgregar = new JButton("Agregar");
+		btnAgregar.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				abrirFormTipoClientes(1, 0);
+			}
+		});
 		btnAgregar.setIcon(new ImageIcon(PanelTipoCliente.class.getResource("/com/kathsoft/kathpos/app/assets/agregar_ico.png")));
 		btnAgregar.setBackground(new Color(144, 238, 144));
 		panelSuperiorBotones.add(btnAgregar);
 		
 		btnModificar = new JButton("Modificar");
+		btnModificar.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				try {
+					int index = DataTools.getIndiceElementoSeleccionado(tableTipoCliente, modelTablaTipoCliente, 0);
+					abrirFormTipoClientes(2, index);
+				}catch (Exception er) {
+					// TODO: handle exception
+					er.printStackTrace();
+				}
+			}
+		});
 		btnModificar.setIcon(new ImageIcon(PanelTipoCliente.class.getResource("/com/kathsoft/kathpos/app/assets/actualizar_ico.png")));
 		btnModificar.setBackground(new Color(144, 238, 144));
 		panelSuperiorBotones.add(btnModificar);
 		
 		btnEliminar = new JButton("Eliminar");
+		btnEliminar.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				eliminarTipoCliente();
+			}
+		});
 		btnEliminar.setIcon(new ImageIcon(PanelTipoCliente.class.getResource("/com/kathsoft/kathpos/app/assets/nwCancel.png")));
 		btnEliminar.setBackground(new Color(255, 51, 0));
 		panelSuperiorBotones.add(btnEliminar);
@@ -209,6 +226,22 @@ public class PanelTipoCliente extends JPanel {
 		this.tableTipoCliente.updateUI();
 		
 		AppContext.tipoClienteController.listarTipoCliente(nombre).forEach(modelTablaTipoCliente::addRow);
+		
+	}
+	
+	private void eliminarTipoCliente() {
+		
+		int index = DataTools.getIndiceElementoSeleccionado(this.tableTipoCliente, modelTablaTipoCliente, 0);
+		if(index < 0) {
+			MessageHandler.displayMessage(MessageHandler.WARN_MESSAGE, this, "Debe seleccionar un registro");
+			return;
+		}
+		
+		var result = AppContext.tipoClienteController.eliminarTipoCliente(index);
+		
+		MessageHandler.displayMessage(
+				result.id() == 200 ?
+				MessageHandler.DELETE_SUCCESS_MESSAGE : MessageHandler.ERROR_MESSAGE, this, result.message());
 		
 	}
 	


### PR DESCRIPTION
# Cambios principales:
- Se le asignan las acciones correspondientes a los botones en el panel principal.
- Se modifican los métodos en controladores que agregan, actualizan y eliminan datos. pasan de ser void a ser de tipo `SpResponse` mapeando de esta forma una respuesta directa desde el procedimiento almacenado.
- A los procedimientos almacenados se les agregó un manejador de errores:
```
DECLARE v_sqlState CHAR(5);
	DECLARE v_errno INT;
	DECLARE v_text TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
	
	DECLARE EXIT HANDLER FOR SQLEXCEPTION
	BEGIN
		
		GET DIAGNOSTICS CONDITION 1
		v_sqlState = RETURNED_SQLSTATE,
		v_errno = MYSQL_ERRNO,
		v_text = MESSAGE_TEXT;
		
		SELECT 500 AS id,
		CONCAT('Error ', v_errno, ' (', v_sqlState, ' ):', v_text) AS message;
		
	END;
``` 
## Por qué este cambio ?

De esta forma se tiene una respuesta mas clara y limpia desde la base de datos tanto para el exito de las operaciones como en los posibles errores obtenidos.