### PR TITLE
Documentación y Funcionalidades en Telefonos de empleados

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,7 +2,6 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
-			<attribute name="module" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
@@ -48,11 +47,11 @@
 	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
 		<attributes>
-			<attribute name="ignore_optional_problems" value="true"/>
-			<attribute name="test" value="true"/>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
 			<attribute name="m2e-apt" value="true"/>
+			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,6 @@
 eclipse.preferences.version=1
 encoding//src/main/java=UTF-8
+encoding//src/main/resources=UTF-8
 encoding//src/test/java=UTF-8
+encoding//src/test/resources=UTF-8
 encoding/<project>=UTF-8

--- a/src/main/java/com/kathsoft/kathpos/app/controller/TelefonoEmpleadoController.java
+++ b/src/main/java/com/kathsoft/kathpos/app/controller/TelefonoEmpleadoController.java
@@ -9,11 +9,58 @@ import com.kathsoft.kathpos.app.model.telefono_x_empleado.TelefonoEmpleado;
 import com.kathsoft.kathpos.app.model.viewmodel.SpResponseModel;
 import com.kathsoft.kathpos.tools.Conexion;
 
+/**
+ * Controlador responsable de gestionar las operaciones relacionadas con los
+ * números telefónicos asociados a los empleados.
+ *
+ * <p>
+ * Esta clase proporciona métodos para consultar y registrar números
+ * telefónicos mediante procedimientos almacenados ejecutados sobre la base de
+ * datos local configurada en {@link Conexion}.
+ * </p>
+ *
+ * <p>
+ * Las respuestas de las operaciones de escritura se encapsulan mediante
+ * {@link SpResponseModel}.
+ * </p>
+ *
+ * @author Pablo Gómez Pérez
+ * @since 1.0
+ */
 public class TelefonoEmpleadoController {
 
 	public TelefonoEmpleadoController() {
 	};
 
+	/**
+	 * Consulta los números telefónicos asociados a un empleado.
+	 *
+	 * <p>
+	 * El método ejecuta el procedimiento almacenado
+	 * {@code listTelefonosDeEmpleadoByID} y transforma cada registro obtenido en
+	 * un arreglo de objetos con la siguiente estructura:
+	 * </p>
+	 *
+	 * <ol>
+	 * 	<li>Identificador del teléfono.</li>
+	 * 	<li>Número telefónico.</li>
+	 * </ol>
+	 *
+	 * <p>
+	 * Si ocurre un error durante la consulta, se imprime la traza de la excepción
+	 * y se retorna el vector con los registros recuperados hasta ese momento. Si
+	 * no se recuperó ningún registro, el vector retornado estará vacío.
+	 * </p>
+	 *
+	 * @param idEmpleado identificador único del empleado cuyos teléfonos se
+	 *                   desean consultar
+	 * @return un {@link Vector} de arreglos {@link Object} que contiene el
+	 *         identificador y el número de cada teléfono asociado al empleado;
+	 *         nunca retorna {@code null}
+	 *
+	 * @see Vector
+	 * @see Object
+	 */
 	public Vector<Object[]> listTelefonoPorIdEmpleado(int idEmpleado) {
 
 		var data = new Vector<Object[]>();
@@ -37,6 +84,39 @@ public class TelefonoEmpleadoController {
 
 	}
 	
+	/**
+	 * Registra un número telefónico asociado a un empleado.
+	 *
+	 * <p>
+	 * El método ejecuta el procedimiento almacenado
+	 * {@code insertTelefonoEmpleado}, enviando el identificador del empleado y
+	 * el número telefónico contenidos en el objeto recibido.
+	 * </p>
+	 *
+	 * <p>
+	 * El procedimiento almacenado debe retornar un conjunto de resultados con
+	 * las columnas {@code id} y {@code message}. Estos valores se utilizan para
+	 * construir el objeto {@link SpResponseModel}.
+	 * </p>
+	 *
+	 * <p>
+	 * Si el procedimiento no retorna ningún registro, se genera una respuesta
+	 * con código {@code 500}. Si ocurre una excepción, también se retorna una
+	 * respuesta con código {@code 500} y el mensaje proporcionado por la
+	 * excepción.
+	 * </p>
+	 *
+	 * @param telefonoEmpleado objeto que contiene el identificador del empleado
+	 *                         y el número telefónico que se desea registrar
+	 * @return una instancia de {@link SpResponseModel} con el identificador y el
+	 *         mensaje retornados por el procedimiento almacenado; en caso de
+	 *         error, retorna una respuesta con código {@code 500}
+	 *
+	 * @throws NullPointerException si {@code telefonoEmpleado} es {@code null}
+	 *
+	 * @see TelefonoEmpleado
+	 * @see SpResponseModel
+	 */
 	public SpResponseModel createTelefonoEmpleado(TelefonoEmpleado telefonoEmpleado) {
 		
 		try(Connection cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
@@ -61,5 +141,7 @@ public class TelefonoEmpleadoController {
 		
 		
 	}
+	
+	
 
 }

--- a/src/main/java/com/kathsoft/kathpos/app/controller/TelefonoEmpleadoController.java
+++ b/src/main/java/com/kathsoft/kathpos/app/controller/TelefonoEmpleadoController.java
@@ -142,6 +142,62 @@ public class TelefonoEmpleadoController {
 		
 	}
 	
-	
+	/**
+	 * Elimina un número telefónico asociado a un empleado.
+	 *
+	 * <p>
+	 * El método ejecuta el procedimiento almacenado
+	 * {@code deleteTelefonoEmpleado}, el cual valida previamente la existencia del
+	 * número telefónico antes de eliminarlo de la tabla
+	 * {@code telefono_x_empleado}.
+	 * </p>
+	 *
+	 * <p>
+	 * El procedimiento almacenado retorna un conjunto de resultados con las
+	 * columnas {@code id} y {@code message}, las cuales son utilizadas para
+	 * construir el objeto {@link SpResponseModel} que representa el resultado de
+	 * la operación.
+	 * </p>
+	 *
+	 * <p>
+	 * Si el procedimiento no retorna ningún registro, se genera una respuesta con
+	 * código {@code 500}. En caso de producirse una excepción durante la ejecución,
+	 * la traza del error es enviada a la salida de error estándar y se retorna un
+	 * {@link SpResponseModel} con código {@code 500} y el mensaje de la excepción.
+	 * </p>
+	 *
+	 * @param idTelefono identificador único del número telefónico que se desea
+	 *                   eliminar
+	 * @return una instancia de {@link SpResponseModel} que contiene el código y el
+	 *         mensaje devueltos por el procedimiento almacenado; en caso de error,
+	 *         retorna una respuesta con código {@code 500}
+	 *
+	 * @see SpResponseModel
+	 * @see TelefonoEmpleado
+	 */
+	public SpResponseModel deleteTelefonoEmpleado(int idTelefono) {
+		
+		try(Connection cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
+				CallableStatement stm = cn.prepareCall("CALL deleteTelefonoEmpleado(?)")){
+			
+			stm.setInt("p_id_telefono", idTelefono);
+			
+			try(ResultSet rset = stm.executeQuery()){
+				
+				if(rset.next()) {
+					return new SpResponseModel(rset.getInt("id"), rset.getString("message"));
+				}
+				
+			}
+			
+			return new SpResponseModel(500, "Ocurrio un error desconocido");
+			
+		}catch (Exception e) {
+			
+			e.printStackTrace(System.err);
+			return new SpResponseModel(500, e.getMessage());
+		}
+		
+	}
 
 }

--- a/src/main/java/com/kathsoft/kathpos/app/view/empleados/Fr_DatosEmpleado.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/empleados/Fr_DatosEmpleado.java
@@ -38,6 +38,7 @@ import com.kathsoft.kathpos.app.model.telefono_x_empleado.TelefonoEmpleado;
 import com.kathsoft.kathpos.app.model.viewmodel.CuentaContableResponseViewModel;
 import com.kathsoft.kathpos.app.model.viewmodel.JComboboxDataViewModel;
 import com.kathsoft.kathpos.tools.AppContext;
+import com.kathsoft.kathpos.tools.DataTools;
 import com.kathsoft.kathpos.tools.MessageHandler;
 import com.kathsoft.kathpos.tools.UiTools;
 
@@ -214,6 +215,12 @@ public class Fr_DatosEmpleado extends JFrame {
 		btnAgregarTelefono.setFont(new Font("Dialog", Font.BOLD, 9));
 
 		btnEliminarTelefono = new JButton("Borrar");
+		btnEliminarTelefono.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent arg0) {
+				eliminarTelefonoEmpleado();
+				listarTelefonoDeEmpleado(idEmpleado);
+			}
+		});
 		btnEliminarTelefono.setFont(new Font("Dialog", Font.BOLD, 9));
 		btnEliminarTelefono.setBackground(new Color(255, 102, 102));
 
@@ -621,9 +628,31 @@ public class Fr_DatosEmpleado extends JFrame {
 		
 		String telefono = JOptionPane.showInputDialog(this, "Indique el número a registrar:", "Telefonos", JOptionPane.INFORMATION_MESSAGE);
 		
+		if(telefono == null || telefono.length() <= 0) {
+			MessageHandler.displayMessage(MessageHandler.WARN_MESSAGE, this, "Indique el número telefonico");
+		}
+		
 		var result = AppContext.telefonoEmpleadoController.createTelefonoEmpleado(new TelefonoEmpleado(0, idEmpleado, telefono));
 		
 		MessageHandler.displayMessage(result.id() == 200 ? MessageHandler.CREATE_SUCCESS_MESSAGE: MessageHandler.ERROR_MESSAGE, this, result.message());
+		
+		listarTelefonoDeEmpleado(idEmpleado);
+		
+	}
+	
+	
+	private void eliminarTelefonoEmpleado() {
+		
+		int idTelefono = DataTools.getIndiceElementoSeleccionado(tableNumerosTelefonicos, modelTablaTelefonoEmpleado, 0);
+		
+		if(idTelefono < 0) {
+			MessageHandler.displayMessage(MessageHandler.WARN_MESSAGE, this, "Debe seleccionar un elemento");
+			return;
+		}
+		
+		var result = AppContext.telefonoEmpleadoController.deleteTelefonoEmpleado(idTelefono);
+		
+		MessageHandler.displayMessage(result.id() == 200 ? MessageHandler.DELETE_SUCCESS_MESSAGE : MessageHandler.ERROR_MESSAGE, this, result.message());
 		
 	}
 }


### PR DESCRIPTION
# Principales Cambios:
- Se escribe el javadoc para toda la clase `TelefonoEmpleadoController` y sus métodos.
- Se valida la longitud del npumero telefonico al registrarlo
- Se Crea procedimiento almacenado para eliminar un numero telefonico de un empleado.
- Se crean métodos y eventos para eliminar un telefono de un empleado.
- Se actualiza la tabla de telefonos de empleados despues de cada acción.

## Problemas que resuelve:

**Al eliminar un empleado** basta con solo seleccionarlo de la tabla.
Lo importante eran las respuestas despues de cada acción dado que el estado de la tabla era exactamente el mismo despues de agregar o eliminar un número telefónico.
> La tabla solo era actualizada hasta abrir nuevamente el formulario

Al momento de agregar un número telefónico ahora ya se valida la longitud de este. de esa forma ya no se almacenan registros fantasmas