### PR TITLE
Fix: retorna SpResponseModel al eliminar cliente

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/controller/ClientesController.java
+++ b/src/main/java/com/kathsoft/kathpos/app/controller/ClientesController.java
@@ -60,18 +60,41 @@ public class ClientesController implements Serializable {
 		}
 	}
 
-	public void eliminarCliente(int idCliente) throws SQLException {
+	public SpResponseModel eliminarCliente(int idCliente) {
 
 		CallableStatement stm = null;
+		ResultSet rset = null;
 
-		cn = Conexion.establecerConexionLocal("kath_erp");
-		stm = cn.prepareCall("CALL eliminar_cliente(?);");
-		stm.setInt(1, idCliente);
+		try {
 
-		stm.execute();
+			cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
+			stm = cn.prepareCall("CALL deleteCliente(?);");
+			stm.setInt("p_id_cliente", idCliente);
 
-		Conexion.cerrarConexion(cn, stm);
+			if (stm.execute()) {
+				rset = stm.getResultSet();
+				if (rset != null && rset.next()) {
+					return new SpResponseModel(rset.getInt("id"), rset.getString("message"));
+				}
+			}
 
+			return new SpResponseModel(500, "Ocurrio un error desconocido");
+
+		} catch (SQLException er) {
+			er.printStackTrace();
+			return new SpResponseModel(500, er.getMessage());
+		} catch (Exception er) {
+			er.printStackTrace();
+			return new SpResponseModel(500, er.getMessage());
+		} finally {
+			try {
+				Conexion.cerrarConexion(cn, rset, stm);
+			} catch (SQLException er) {
+				er.printStackTrace();
+			} catch (Exception er) {
+				er.printStackTrace();
+			}
+		}
 	}
 
 	public void consultarRFCClientes(JComboBox<String> cmb) throws SQLException, Exception {


### PR DESCRIPTION
# Summary:

Este pull request modifica únicamente el controlador de clientes para que la eliminación de cliente retorne una respuesta estandarizada mediante `SpResponseModel`.

## Principales cambios:

- Se actualizó `eliminarCliente(int idCliente)` para retornar `SpResponseModel`.
- Se cambió la llamada del procedimiento anterior `eliminar_cliente` al nuevo procedimiento `deleteCliente`.
- Se agregó lectura del resultado del procedimiento almacenado mediante las columnas `id` y `message`.
- Se estandarizó el manejo de errores para retornar código `500` cuando ocurra una excepción o una respuesta inesperada.

## Correcciones:

- Se eliminó el flujo anterior basado en `void` y `execute()` sin respuesta.
- Se alineó la eliminación de clientes con el patrón usado en `insertarNuevoCliente` y `actualizarCliente`.
- Se actualizó la conexión para usar `Conexion.DATA_BASE`.

## Pendientes:

- [x] Crear o validar el procedimiento almacenado `deleteCliente` en base de datos.
- [ ] Modificar `PanelClientes` para consumir el `SpResponseModel` retornado por el controlador.
- [ ] Mostrar mensajes de éxito o error desde la vista según la respuesta del procedimiento almacenado.