### PR TITLE
Fix: llama eliminacion de cliente desde panel

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/view/clientes/PanelClientes.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/clientes/PanelClientes.java
@@ -144,6 +144,11 @@ public class PanelClientes extends JPanel {
 		panelSuperiorBotones.add(btnModificar);
 
 		btnEliminar = new JButton("Eliminar");
+		btnEliminar.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				eliminarCliente();
+			}
+		});
 		btnEliminar.setIcon(
 				new ImageIcon(PanelClientes.class.getResource("/com/kathsoft/kathpos/app/assets/nwCancel.png")));
 		this.btnEliminar.setBackground(new Color(255, 51, 0));
@@ -221,6 +226,31 @@ public class PanelClientes extends JPanel {
 	private void borrarElementosDeLaTablaClientes() {
 		this.modelTablaClientes.getDataVector().removeAllElements();
 		this.tablaClientes.updateUI();
+	}
+	
+	private void eliminarCliente() {
+		
+		int selectedRow = this.tablaClientes.getSelectedRow();
+		
+		if (selectedRow < 0) return;
+		
+		int modelRow = this.tablaClientes.convertRowIndexToModel(selectedRow);
+		int idCliente = (int) this.modelTablaClientes.getValueAt(modelRow, 0);
+		
+		int option = MessageHandler.displayMessage(MessageHandler.DELETE_DATA_QUESTION_MESSAGE, this, " seleccionado?");
+		
+		if (option != 0) return;
+		
+		var response = AppContext.clientesController.eliminarCliente(idCliente);
+		
+		if (response.id() == 200) {
+			MessageHandler.displayMessage(MessageHandler.DELETE_SUCCESS_MESSAGE, this, response.message());
+			this.llenarTablaClientes();
+			return;
+		}
+		
+		MessageHandler.displayMessage(MessageHandler.ERROR_MESSAGE, this, response.message());
+		
 	}
 	
 	private void abrirFormDatosCliente(int idOperacion, int idCliente) {


### PR DESCRIPTION
# Summary:

Este pull request conecta la accion de eliminacion desde `PanelClientes` con el metodo `eliminarCliente` del controlador.

## Principales cambios:

- Se agrego `ActionListener` al boton `Eliminar` del panel de clientes.
- Se agrego el metodo privado `eliminarCliente()` en `PanelClientes`.
- Se obtiene el cliente seleccionado desde la tabla sin mostrar errores cuando no hay seleccion.
- Se solicita confirmacion antes de ejecutar la baja del cliente.
- Se consume el `SpResponseModel` retornado por `AppContext.clientesController.eliminarCliente(idCliente)`.
- Se refresca la tabla cuando la eliminacion retorna codigo `200`.

## Correcciones:

- Se evita ejecutar la baja si no hay una fila seleccionada.
- Se muestran mensajes de exito o error segun la respuesta del procedimiento almacenado.
- Se conserva la baja logica y validacion contable delegadas al procedimiento `deleteCliente`.

## Pendientes:

- [ ] Probar el flujo completo con un cliente sin saldo en cuenta contable.
- [ ] Probar el bloqueo de eliminacion con cuenta contable con saldo.
- [ ] Revisar posteriormente el mensaje de confirmacion para hacerlo mas descriptivo.