### PR TITLE
Fix: lista proveedores en PanelProveedor

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/view/proveedor/PanelProveedor.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/proveedor/PanelProveedor.java
@@ -124,6 +124,11 @@ public class PanelProveedor extends JPanel {
 		lblNombre = new JLabel("Nombre");
 		
 		btnBuscar = new JButton("Buscar");
+		btnBuscar.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				llenarTablaProveedor(txfNombreProveedor.getText());
+			}
+		});
 		btnBuscar.setIcon(new ImageIcon(PanelProveedor.class.getResource("/com/kathsoft/kathpos/app/assets/buscar_ico.png")));
 		
 		txfNombreProveedor = new JTextField();
@@ -151,7 +156,8 @@ public class PanelProveedor extends JPanel {
 					.addContainerGap(23, Short.MAX_VALUE))
 		);
 		panelInferiorBusqueda.setLayout(gl_panelInferiorBusqueda);
-		panelCentralContenedor.setLayout(gl_panelCentralContenedor);		
+		panelCentralContenedor.setLayout(gl_panelCentralContenedor);
+		this.llenarTablaProveedor("");
 
 	}
 	
@@ -160,6 +166,17 @@ public class PanelProveedor extends JPanel {
 	private void borrarElementosDeLaTablaProveedor() {
 		this.modelTablaProveedores.getDataVector().removeAllElements();
 		this.tablaProveedor.updateUI();
+	}
+	
+	public void llenarTablaProveedor(String nombre) {
+		this.borrarElementosDeLaTablaProveedor();
+		var proveedores = AppContext.proveedorController.verProveedoresEnTabla(nombre);
+		
+		if (proveedores == null || proveedores.isEmpty()) {
+			return;
+		}
+		
+		proveedores.forEach(this.modelTablaProveedores::addRow);
 	}
 	
 	private DefaultTableModel setTableModel() {


### PR DESCRIPTION
# Summary:

Este pull request conecta `PanelProveedor` con el controlador para cargar proveedores en la tabla principal y habilita la búsqueda por nombre desde el botón `btnBuscar`.

## Principales cambios:

- Se agregó la carga inicial de proveedores al abrir `PanelProveedor`.
- Se agregó el método `llenarTablaProveedor(String nombre)`.
- Se reutilizó el modelo existente `modelTablaProveedores` para poblar el `JTable`.
- Se llama a `AppContext.proveedorController.verProveedoresEnTabla(nombre)` para obtener los datos.
- Se agregó el evento de `btnBuscar` para filtrar proveedores usando `txfNombreProveedor`.
- Se limpia la tabla antes de cargar nuevos resultados.

## Correcciones:

- Se habilitó el listado visible de proveedores desde el panel principal.
- Se habilitó la búsqueda de proveedores por el texto capturado en `txfNombreProveedor`.
- Se conserva el modelo de tabla ya definido en la vista.
- Se mantiene el cambio limitado únicamente a `PanelProveedor`.

## Pendientes:

- [ ] Conectar botón `btnAgregar` con `Fr_DatosProveedor`.
- [ ] Conectar botón `btnModificar` con `Fr_DatosProveedor`.
- [ ] Conectar botón `btnEliminar` con el flujo de baja de proveedor.
- [ ] Refrescar la tabla después de alta, modificación o eliminación.