### PR TITLE
Fix: agrega ProveedorById y actualiza consulta por id

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/controller/ProveedorController.java
+++ b/src/main/java/com/kathsoft/kathpos/app/controller/ProveedorController.java
@@ -8,9 +8,9 @@ import java.util.Vector;
 
 import javax.swing.JComboBox;
 import javax.swing.JOptionPane;
-import javax.swing.table.DefaultTableModel;
 
 import com.kathsoft.kathpos.app.model.proveedor.Proveedor;
+import com.kathsoft.kathpos.app.model.proveedor.ProveedorById;
 import com.kathsoft.kathpos.app.model.viewmodel.SpResponseModel;
 import com.kathsoft.kathpos.tools.Conexion;
 
@@ -337,52 +337,41 @@ public class ProveedorController implements java.io.Serializable {
 
 	}
 
-	public Proveedor buscarProveedorPorId(int idProveedor) {
+	public ProveedorById buscarProveedorPorId(int idProveedor) {
 
-		Proveedor prv = new Proveedor();
-		CallableStatement stm = null;
-		ResultSet rset = null;
+		try (
+				Connection cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
+				CallableStatement stm = cn.prepareCall("CALL getProveedorById(?);")
+		) {
 
-		try {
+			stm.setInt("idProveedor", idProveedor);
 
-			cn = Conexion.establecerConexionLocal("kath_erp");
-			stm = cn.prepareCall("CALL buscar_proveedor_por_id(?);");
-			stm.setInt(1, idProveedor);
+			try (ResultSet rset = stm.executeQuery()) {
 
-			rset = stm.executeQuery();
+				if (rset.next()) {
+					return new ProveedorById.ProveedorByIdBuilder()
+							.idProveedor(rset.getInt("id_proveedor"))
+							.idCuentaContable(rset.getInt("id_cuenta_contable"))
+							.claveCuentaContable(rset.getString("clave"))
+							.nombre(rset.getString("nombre"))
+							.descripcion(rset.getString("descripcion"))
+							.correoElectronico(rset.getString("correo_electronico"))
+							.estado(rset.getString("estado"))
+							.ciudad(rset.getString("ciudad"))
+							.direccion(rset.getString("direccion"))
+							.codigoPostal(rset.getString("codigo_postal"))
+							.activo(rset.getBoolean("activo"))
+							.build();
+				}
 
-			if (rset.next()) {
-				prv.setIdProveedor(rset.getInt(1));
-				prv.setRfc(rset.getString(2));
-				prv.setIdCuentaContable(rset.getInt(3));				
-				prv.setNombre(rset.getString(5));
-				prv.setDescripcion(rset.getString(6));
-				prv.setCorreoElectronico(rset.getString(7));
-				prv.setEstado(rset.getString(8));
-				prv.setCiudad(rset.getString(9));
-				prv.setDireccion(rset.getString(10));
-				prv.setCodigoPostal(rset.getString(11));
 			}
-
-			return prv;
 
 		} catch (SQLException er) {
-			er.printStackTrace();
-			JOptionPane.showMessageDialog(null, er.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
-			return null;
+			er.printStackTrace(System.err);
 		} catch (Exception er) {
-			er.printStackTrace();
-			JOptionPane.showMessageDialog(null, er.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
-			return null;
-		} finally {
-			try {
-
-				Conexion.cerrarConexion(cn, rset, stm);
-
-			} catch (Exception er) {
-				er.printStackTrace();
-			}
+			er.printStackTrace(System.err);
 		}
 
+		return null;
 	}
 }

--- a/src/main/java/com/kathsoft/kathpos/app/model/proveedor/ProveedorById.java
+++ b/src/main/java/com/kathsoft/kathpos/app/model/proveedor/ProveedorById.java
@@ -1,0 +1,212 @@
+package com.kathsoft.kathpos.app.model.proveedor;
+
+/**
+ * Modelo de lectura para consultar un proveedor por identificador.
+ *
+ * <p>Representa la respuesta del procedimiento almacenado
+ * {@code getProveedorById}.</p>
+ *
+ * @author PABLO
+ */
+public class ProveedorById {
+
+	private int idProveedor;
+	private int idCuentaContable;
+	private String claveCuentaContable;
+	private String nombre;
+	private String descripcion;
+	private String correoElectronico;
+	private String estado;
+	private String ciudad;
+	private String direccion;
+	private String codigoPostal;
+	private boolean activo;
+
+	public ProveedorById() {
+		super();
+	}
+
+	public ProveedorById(int idProveedor, int idCuentaContable, String claveCuentaContable, String nombre,
+			String descripcion, String correoElectronico, String estado, String ciudad, String direccion,
+			String codigoPostal, boolean activo) {
+		super();
+		this.idProveedor = idProveedor;
+		this.idCuentaContable = idCuentaContable;
+		this.claveCuentaContable = claveCuentaContable;
+		this.nombre = nombre;
+		this.descripcion = descripcion;
+		this.correoElectronico = correoElectronico;
+		this.estado = estado;
+		this.ciudad = ciudad;
+		this.direccion = direccion;
+		this.codigoPostal = codigoPostal;
+		this.activo = activo;
+	}
+
+	public int getIdProveedor() {
+		return idProveedor;
+	}
+
+	public void setIdProveedor(int idProveedor) {
+		this.idProveedor = idProveedor;
+	}
+
+	public int getIdCuentaContable() {
+		return idCuentaContable;
+	}
+
+	public void setIdCuentaContable(int idCuentaContable) {
+		this.idCuentaContable = idCuentaContable;
+	}
+
+	public String getClaveCuentaContable() {
+		return claveCuentaContable;
+	}
+
+	public void setClaveCuentaContable(String claveCuentaContable) {
+		this.claveCuentaContable = claveCuentaContable;
+	}
+
+	public String getNombre() {
+		return nombre;
+	}
+
+	public void setNombre(String nombre) {
+		this.nombre = nombre;
+	}
+
+	public String getDescripcion() {
+		return descripcion;
+	}
+
+	public void setDescripcion(String descripcion) {
+		this.descripcion = descripcion;
+	}
+
+	public String getCorreoElectronico() {
+		return correoElectronico;
+	}
+
+	public void setCorreoElectronico(String correoElectronico) {
+		this.correoElectronico = correoElectronico;
+	}
+
+	public String getEstado() {
+		return estado;
+	}
+
+	public void setEstado(String estado) {
+		this.estado = estado;
+	}
+
+	public String getCiudad() {
+		return ciudad;
+	}
+
+	public void setCiudad(String ciudad) {
+		this.ciudad = ciudad;
+	}
+
+	public String getDireccion() {
+		return direccion;
+	}
+
+	public void setDireccion(String direccion) {
+		this.direccion = direccion;
+	}
+
+	public String getCodigoPostal() {
+		return codigoPostal;
+	}
+
+	public void setCodigoPostal(String codigoPostal) {
+		this.codigoPostal = codigoPostal;
+	}
+
+	public boolean isActivo() {
+		return activo;
+	}
+
+	public void setActivo(boolean activo) {
+		this.activo = activo;
+	}
+
+	@Override
+	public String toString() {
+		return "ProveedorById [idProveedor=" + idProveedor + ", idCuentaContable=" + idCuentaContable
+				+ ", claveCuentaContable=" + claveCuentaContable + ", nombre=" + nombre + ", descripcion=" + descripcion
+				+ ", correoElectronico=" + correoElectronico + ", estado=" + estado + ", ciudad=" + ciudad
+				+ ", direccion=" + direccion + ", codigoPostal=" + codigoPostal + ", activo=" + activo + "]";
+	}
+
+	/**
+	 * Constructor fluido para crear instancias de {@link ProveedorById}.
+	 */
+	public static class ProveedorByIdBuilder {
+
+		private final ProveedorById proveedor;
+
+		public ProveedorByIdBuilder() {
+			this.proveedor = new ProveedorById();
+		}
+
+		public ProveedorByIdBuilder idProveedor(int idProveedor) {
+			this.proveedor.idProveedor = idProveedor;
+			return this;
+		}
+
+		public ProveedorByIdBuilder idCuentaContable(int idCuentaContable) {
+			this.proveedor.idCuentaContable = idCuentaContable;
+			return this;
+		}
+
+		public ProveedorByIdBuilder claveCuentaContable(String claveCuentaContable) {
+			this.proveedor.claveCuentaContable = claveCuentaContable;
+			return this;
+		}
+
+		public ProveedorByIdBuilder nombre(String nombre) {
+			this.proveedor.nombre = nombre;
+			return this;
+		}
+
+		public ProveedorByIdBuilder descripcion(String descripcion) {
+			this.proveedor.descripcion = descripcion;
+			return this;
+		}
+
+		public ProveedorByIdBuilder correoElectronico(String correoElectronico) {
+			this.proveedor.correoElectronico = correoElectronico;
+			return this;
+		}
+
+		public ProveedorByIdBuilder estado(String estado) {
+			this.proveedor.estado = estado;
+			return this;
+		}
+
+		public ProveedorByIdBuilder ciudad(String ciudad) {
+			this.proveedor.ciudad = ciudad;
+			return this;
+		}
+
+		public ProveedorByIdBuilder direccion(String direccion) {
+			this.proveedor.direccion = direccion;
+			return this;
+		}
+
+		public ProveedorByIdBuilder codigoPostal(String codigoPostal) {
+			this.proveedor.codigoPostal = codigoPostal;
+			return this;
+		}
+
+		public ProveedorByIdBuilder activo(boolean activo) {
+			this.proveedor.activo = activo;
+			return this;
+		}
+
+		public ProveedorById build() {
+			return this.proveedor;
+		}
+	}
+}


### PR DESCRIPTION
# Summary:

Este pull request agrega el modelo `ProveedorById` y actualiza la consulta individual de proveedores para consumir el nuevo procedimiento almacenado `getProveedorById`.

## Principales cambios:

- Se creó la clase `ProveedorById` dentro del package `com.kathsoft.kathpos.app.model.proveedor`.
- Se agregó la clase interna `ProveedorByIdBuilder` para construir instancias de forma fluida.
- Se actualizaron los campos del modelo de consulta por ID para incluir:
  - `idProveedor`
  - `idCuentaContable`
  - `claveCuentaContable`
  - `nombre`
  - `descripcion`
  - `correoElectronico`
  - `estado`
  - `ciudad`
  - `direccion`
  - `codigoPostal`
  - `activo`
- Se modificó `buscarProveedorPorId(int idProveedor)` en `ProveedorController` para retornar `ProveedorById`.
- Se cambió la llamada anterior a `buscar_proveedor_por_id` por el nuevo procedimiento almacenado `getProveedorById`.
- Se mapeó la respuesta del procedimiento usando nombres de columnas.
- Se aplicó `try-with-resources` en la consulta individual por ID.

## Correcciones:

- Se separó el modelo general `Proveedor` del modelo específico de consulta por ID.
- Se incorporó la clave de cuenta contable proveniente del join con `cuentas_contables`.
- Se eliminó el mapeo anterior basado en índices numéricos para la consulta individual.
- Se alineó el controlador con la estructura actual del procedimiento almacenado `getProveedorById`.

## Pendientes:

- [ ] Integrar `ProveedorById` en `Fr_DatosProveedor` para cargar datos en modo actualización.
- [ ] Validar que el procedimiento `getProveedorById` retorne un solo registro por proveedor.
- [x] Revisar posteriormente la consulta SQL del procedimiento para confirmar que el `JOIN` con `cuentas_contables` incluya condición explícita entre `pr.id_cuenta_contable` y `cc.id_cuenta`.