### PR TITLE
Feat: agrega telefonos de proveedor

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/controller/TelefonosProveedorController.java
+++ b/src/main/java/com/kathsoft/kathpos/app/controller/TelefonosProveedorController.java
@@ -1,0 +1,141 @@
+package com.kathsoft.kathpos.app.controller;
+
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Vector;
+
+import com.kathsoft.kathpos.app.model.proveedor.TelefonoProveedor;
+import com.kathsoft.kathpos.app.model.viewmodel.SpResponseModel;
+import com.kathsoft.kathpos.tools.Conexion;
+
+/**
+ * Controlador para gestionar los telefonos asociados a proveedores.
+ *
+ * @author PABLO
+ */
+public class TelefonosProveedorController implements java.io.Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Lista los telefonos asociados a un proveedor.
+	 *
+	 * @param idProveedor identificador del proveedor
+	 * @return vector con los telefonos encontrados; nunca retorna {@code null}
+	 */
+	public Vector<Object[]> listTelefonosProveedor(int idProveedor) {
+
+		var data = new Vector<Object[]>();
+
+		try (
+				Connection cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
+				CallableStatement stm = cn.prepareCall("CALL listTelefonoProveedor(?);")
+		) {
+
+			stm.setInt("p_id_proveedor", idProveedor);
+
+			try (ResultSet rset = stm.executeQuery()) {
+
+				while (rset.next()) {
+					data.add(new Object[] {
+							rset.getInt("id_telefono"),
+							rset.getString("telefono")
+					});
+				}
+
+			}
+
+		} catch (SQLException er) {
+			er.printStackTrace(System.err);
+		} catch (Exception er) {
+			er.printStackTrace(System.err);
+		}
+
+		return data;
+	}
+
+	/**
+	 * Registra un telefono asociado a un proveedor.
+	 *
+	 * @param data datos del telefono a registrar
+	 * @return respuesta estandarizada del procedimiento almacenado
+	 */
+	public SpResponseModel insertTelefonoProveedor(TelefonoProveedor data) {
+
+		try (
+				Connection cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
+				CallableStatement stm = cn.prepareCall("CALL insertTelefonoProveedor(?, ?);")
+		) {
+
+			stm.setInt("p_id_proveedor", data.getIdProveedor());
+			stm.setString("p_telefono", data.getTelefono());
+
+			if (stm.execute()) {
+
+				try (ResultSet rset = stm.getResultSet()) {
+
+					if (rset != null && rset.next()) {
+						return new SpResponseModel(
+								rset.getInt("id"),
+								rset.getString("message")
+						);
+					}
+
+				}
+
+			}
+
+			return new SpResponseModel(500, "Ocurrio un error desconocido");
+
+		} catch (SQLException er) {
+			er.printStackTrace(System.err);
+			return new SpResponseModel(500, er.getMessage());
+		} catch (Exception er) {
+			er.printStackTrace(System.err);
+			return new SpResponseModel(500, er.getMessage());
+		}
+	}
+
+	/**
+	 * Elimina un telefono asociado a un proveedor.
+	 *
+	 * @param idTelefono identificador del telefono
+	 * @return respuesta estandarizada del procedimiento almacenado
+	 */
+	public SpResponseModel deleteTelefonoProveedor(int idTelefono) {
+
+		try (
+				Connection cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
+				CallableStatement stm = cn.prepareCall("CALL deleteTelefonoProveedor(?);")
+		) {
+
+			stm.setInt("p_id_telefono", idTelefono);
+
+			if (stm.execute()) {
+
+				try (ResultSet rset = stm.getResultSet()) {
+
+					if (rset != null && rset.next()) {
+						return new SpResponseModel(
+								rset.getInt("id"),
+								rset.getString("message")
+						);
+					}
+
+				}
+
+			}
+
+			return new SpResponseModel(500, "Ocurrio un error desconocido");
+
+		} catch (SQLException er) {
+			er.printStackTrace(System.err);
+			return new SpResponseModel(500, er.getMessage());
+		} catch (Exception er) {
+			er.printStackTrace(System.err);
+			return new SpResponseModel(500, er.getMessage());
+		}
+	}
+}

--- a/src/main/java/com/kathsoft/kathpos/app/model/proveedor/TelefonoProveedor.java
+++ b/src/main/java/com/kathsoft/kathpos/app/model/proveedor/TelefonoProveedor.java
@@ -1,0 +1,54 @@
+package com.kathsoft.kathpos.app.model.proveedor;
+
+/**
+ * Representa un numero telefonico asociado a un proveedor.
+ *
+ * @author PABLO
+ */
+public class TelefonoProveedor {
+
+	private int idTelefono;
+	private int idProveedor;
+	private String telefono;
+
+	public TelefonoProveedor() {
+		super();
+	}
+
+	public TelefonoProveedor(int idTelefono, int idProveedor, String telefono) {
+		super();
+		this.idTelefono = idTelefono;
+		this.idProveedor = idProveedor;
+		this.telefono = telefono;
+	}
+
+	public int getIdTelefono() {
+		return idTelefono;
+	}
+
+	public void setIdTelefono(int idTelefono) {
+		this.idTelefono = idTelefono;
+	}
+
+	public int getIdProveedor() {
+		return idProveedor;
+	}
+
+	public void setIdProveedor(int idProveedor) {
+		this.idProveedor = idProveedor;
+	}
+
+	public String getTelefono() {
+		return telefono;
+	}
+
+	public void setTelefono(String telefono) {
+		this.telefono = telefono;
+	}
+
+	@Override
+	public String toString() {
+		return "TelefonoProveedor [idTelefono=" + idTelefono + ", idProveedor=" + idProveedor + ", telefono="
+				+ telefono + "]";
+	}
+}


### PR DESCRIPTION
# Summary:

Este pull request agrega la entidad y el controlador inicial para gestionar los teléfonos asociados a proveedores.

## Principales cambios:

- Se creó la clase `TelefonoProveedor` dentro de `com.kathsoft.kathpos.app.model.proveedor`.
- Se creó `TelefonosProveedorController` dentro de `com.kathsoft.kathpos.app.controller`.
- Se agregó el método `listTelefonosProveedor(int idProveedor)`.
- Se agregó el método `insertTelefonoProveedor(TelefonoProveedor data)`.
- Se agregó el método `deleteTelefonoProveedor(int idTelefono)`.
- Se integraron llamadas a los procedimientos almacenados:
  - `listTelefonoProveedor`
  - `insertTelefonoProveedor`
  - `deleteTelefonoProveedor`
- Se usó `try-with-resources` para `Connection`, `CallableStatement` y `ResultSet`.
- Se mapearon parámetros y columnas por nombre en lugar de índices numéricos.
- Las operaciones de inserción y eliminación retornan `SpResponseModel`.
- El listado retorna `Vector<Object[]>` para integrarse posteriormente con `JTable`.

## Correcciones:

- Se mantiene separado el modelo de teléfono del proveedor respecto al modelo principal `Proveedor`.
- Se estandariza el flujo de respuesta de inserción y eliminación mediante `SpResponseModel`.
- Se evita el cierre manual de recursos JDBC en el controlador nuevo.

## Pendientes:

- [ ] Registrar `TelefonosProveedorController` en `AppContext`.
- [ ] Integrar listado de teléfonos en `Fr_DatosProveedor`.
- [ ] Agregar acción para insertar teléfono desde `Fr_DatosProveedor`.
- [ ] Agregar acción para eliminar teléfono desde `Fr_DatosProveedor`.
- [ ] Refrescar la tabla de teléfonos después de insertar o eliminar.