### PR TITLE
Fix: agrega acciones en PanelProveedor

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/view/proveedor/PanelProveedor.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/proveedor/PanelProveedor.java
@@ -106,14 +106,35 @@ public class PanelProveedor extends JPanel {
 		scrollPaneTablaProveedor.setViewportView(tablaProveedor);
 		
 		btnAgregar = new JButton("Agregar");
+		btnAgregar.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				abrirFormDatosProveedor(0, 0);
+			}
+		});
 		btnAgregar.setIcon(new ImageIcon(PanelProveedor.class.getResource("/com/kathsoft/kathpos/app/assets/agregar_ico.png")));
 		panelSuperiorBotones.add(btnAgregar);
 		
 		btnModificar = new JButton("Modificar");
+		btnModificar.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				int idProveedor = DataTools.getIndiceElementoSeleccionado(tablaProveedor, modelTablaProveedores, 0);
+
+				if (idProveedor < 0) {
+					return;
+				}
+
+				abrirFormDatosProveedor(1, idProveedor);
+			}
+		});
 		btnModificar.setIcon(new ImageIcon(PanelProveedor.class.getResource("/com/kathsoft/kathpos/app/assets/actualizar_ico.png")));
 		panelSuperiorBotones.add(btnModificar);
 		
 		btnEliminar = new JButton("Eliminar");
+		btnEliminar.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				eliminarProveedor();
+			}
+		});
 		btnEliminar.setIcon(new ImageIcon(PanelProveedor.class.getResource("/com/kathsoft/kathpos/app/assets/nwCancel.png")));
 		panelSuperiorBotones.add(btnEliminar);
 		
@@ -177,6 +198,47 @@ public class PanelProveedor extends JPanel {
 		}
 		
 		proveedores.forEach(this.modelTablaProveedores::addRow);
+	}
+	
+	private void eliminarProveedor() {
+
+		if (this.tablaProveedor.getSelectedRow() < 0) {
+			return;
+		}
+
+		int idProveedor = DataTools.getIndiceElementoSeleccionado(this.tablaProveedor, this.modelTablaProveedores, 0);
+
+		if (idProveedor < 0) {
+			return;
+		}
+
+		int option = MessageHandler.displayMessage(MessageHandler.DELETE_DATA_QUESTION_MESSAGE, this, " seleccionado?");
+
+		if (option != 0) {
+			return;
+		}
+
+		var response = AppContext.proveedorController.eliminarProveedor(idProveedor);
+
+		if (response.id() == 200) {
+			MessageHandler.displayMessage(MessageHandler.DELETE_SUCCESS_MESSAGE, this, response.message());
+			this.llenarTablaProveedor(this.txfNombreProveedor.getText());
+			return;
+		}
+
+		MessageHandler.displayMessage(MessageHandler.ERROR_MESSAGE, this, response.message());
+	}
+	
+	private void abrirFormDatosProveedor(int idOperacion, int idProveedor) {
+
+		try {
+			Fr_DatosProveedor form = new Fr_DatosProveedor(idOperacion, idProveedor);
+			form.setLocationRelativeTo(this);
+			form.setVisible(true);
+		} catch (Exception e) {
+			e.printStackTrace(System.err);
+			MessageHandler.displayMessage(MessageHandler.ERROR_MESSAGE, this, e.getMessage());
+		}
 	}
 	
 	private DefaultTableModel setTableModel() {


### PR DESCRIPTION
# Summary:

Este pull request agrega los eventos principales de acción en `PanelProveedor` para abrir el formulario de proveedores y ejecutar la baja lógica del proveedor seleccionado.

## Principales cambios:

- Se agregó evento a `btnAgregar` para abrir `Fr_DatosProveedor` en modo alta.
- Se agregó evento a `btnModificar` para obtener el proveedor seleccionado y abrir `Fr_DatosProveedor` en modo edición.
- Se agregó evento a `btnEliminar` para inhabilitar el proveedor seleccionado.
- Se agregó el método `abrirFormDatosProveedor(int idOperacion, int idProveedor)`.
- Se agregó el método `eliminarProveedor()`.
- Se usa `DataTools.getIndiceElementoSeleccionado()` para obtener el ID del proveedor seleccionado en la tabla.
- Se usa `AppContext.proveedorController.eliminarProveedor(idProveedor)` para ejecutar la baja lógica.
- Se usa `MessageHandler` para confirmaciones, mensajes de éxito y errores.
- Se refresca la tabla únicamente cuando el procedimiento retorna `id = 200`.

## Correcciones:

- Se habilita el flujo básico de alta, modificación y eliminación desde el panel principal de proveedores.
- Se evita ejecutar modificación o eliminación si no hay un proveedor seleccionado.
- Se conserva el filtro actual de búsqueda al refrescar la tabla después de eliminar.
- Se mantiene el cambio limitado únicamente a `PanelProveedor`.

## Pendientes:

- [ ] Actualizar `Fr_DatosProveedor` para guardar proveedores con `SpResponseModel`.
- [ ] Refrescar la tabla después de alta o modificación cuando el formulario implemente estado de operación ejecutada.
- [ ] Integrar teléfonos de proveedor dentro de `Fr_DatosProveedor`.