### PR TITLE
Fix: valida seleccion al modificar proveedor

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/view/proveedor/PanelProveedor.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/proveedor/PanelProveedor.java
@@ -117,6 +117,16 @@ public class PanelProveedor extends JPanel {
 		btnModificar = new JButton("Modificar");
 		btnModificar.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent e) {
+
+				if (tablaProveedor.getSelectedRow() < 0) {
+					MessageHandler.displayMessage(
+							MessageHandler.WARN_MESSAGE,
+							PanelProveedor.this,
+							"Seleccione un proveedor para modificar"
+					);
+					return;
+				}
+
 				int idProveedor = DataTools.getIndiceElementoSeleccionado(tablaProveedor, modelTablaProveedores, 0);
 
 				if (idProveedor < 0) {


### PR DESCRIPTION
# Summary:

Este pull request corrige la excepción generada al presionar `btnModificar` en `PanelProveedor` sin tener un proveedor seleccionado en la tabla.

## Causa del error:

El evento de `btnModificar` llamaba directamente a `DataTools.getIndiceElementoSeleccionado(tablaProveedor, modelTablaProveedores, 0)` sin validar previamente si existía una fila seleccionada.

Cuando no había selección, `tablaProveedor.getSelectedRow()` retornaba `-1`. Ese valor llegaba a la lógica de obtención del índice y provocaba un `IndexOutOfBoundsException`.

## Principales cambios:

- Se agregó validación previa con `tablaProveedor.getSelectedRow() < 0` antes de llamar a `DataTools`.
- Se muestra una advertencia mediante `MessageHandler` cuando el usuario intenta modificar sin seleccionar un proveedor.
- Se conserva el uso de `DataTools.getIndiceElementoSeleccionado()` cuando sí existe una fila seleccionada.
- Se mantiene el flujo de apertura de `Fr_DatosProveedor` únicamente cuando el ID obtenido es válido.

## Correcciones:

- Se evita el `IndexOutOfBoundsException` al pulsar `btnModificar` sin selección.
- Se mejora la experiencia del usuario mostrando un mensaje claro antes de cancelar la acción.
- Se mantiene el cambio limitado a `PanelProveedor`.

## Pendientes:

- [x] Probar modificación con una fila seleccionada.
- [x] Probar modificación sin seleccionar fila.
- [x] Revisar si conviene aplicar el mismo mensaje de advertencia al flujo de eliminación cuando no hay selección.