### PR TITLE
Style: homologa colores de botones en PanelProveedor

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/view/proveedor/PanelProveedor.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/proveedor/PanelProveedor.java
@@ -112,6 +112,7 @@ public class PanelProveedor extends JPanel {
 			}
 		});
 		btnAgregar.setIcon(new ImageIcon(PanelProveedor.class.getResource("/com/kathsoft/kathpos/app/assets/agregar_ico.png")));
+		btnAgregar.setBackground(new Color(144, 238, 144));
 		panelSuperiorBotones.add(btnAgregar);
 		
 		btnModificar = new JButton("Modificar");
@@ -137,6 +138,7 @@ public class PanelProveedor extends JPanel {
 			}
 		});
 		btnModificar.setIcon(new ImageIcon(PanelProveedor.class.getResource("/com/kathsoft/kathpos/app/assets/actualizar_ico.png")));
+		btnModificar.setBackground(new Color(144, 238, 144));
 		panelSuperiorBotones.add(btnModificar);
 		
 		btnEliminar = new JButton("Eliminar");
@@ -146,10 +148,12 @@ public class PanelProveedor extends JPanel {
 			}
 		});
 		btnEliminar.setIcon(new ImageIcon(PanelProveedor.class.getResource("/com/kathsoft/kathpos/app/assets/nwCancel.png")));
+		btnEliminar.setBackground(new Color(255, 51, 0));
 		panelSuperiorBotones.add(btnEliminar);
 		
 		btnToExcel = new JButton("Exportar Excel");
 		btnToExcel.setIcon(new ImageIcon(PanelProveedor.class.getResource("/com/kathsoft/kathpos/app/assets/excelLogo.jpg")));
+		btnToExcel.setBackground(new Color(102, 205, 170));
 		panelSuperiorBotones.add(btnToExcel);
 		
 		lblNombre = new JLabel("Nombre");
@@ -160,6 +164,7 @@ public class PanelProveedor extends JPanel {
 				llenarTablaProveedor(txfNombreProveedor.getText());
 			}
 		});
+		btnBuscar.setBackground(new Color(153, 102, 51));
 		btnBuscar.setIcon(new ImageIcon(PanelProveedor.class.getResource("/com/kathsoft/kathpos/app/assets/buscar_ico.png")));
 		
 		txfNombreProveedor = new JTextField();


### PR DESCRIPTION
# Summary:

Este pull request homologa los colores de los botones de `PanelProveedor` con la temática visual usada en `PanelClientes` y `PanelEmpleados`.

## Principales cambios:

- Se agregó color verde claro a `btnAgregar`.
- Se agregó color verde claro a `btnModificar`.
- Se agregó color rojo a `btnEliminar`.
- Se agregó color verde agua a `btnToExcel`.
- Se agregó color café al botón `btnBuscar`.

## Correcciones:

- Se mantiene consistencia visual entre los paneles principales de clientes, empleados y proveedores.
- El cambio se limita únicamente a estilos de botones en `PanelProveedor`.
- No se modifica lógica de negocio, eventos, consultas ni estructura del layout.