### PR TITLE
Fix: actualiza CategoriaController con nuevos SP

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/controller/CategoriaController.java
+++ b/src/main/java/com/kathsoft/kathpos/app/controller/CategoriaController.java
@@ -12,6 +12,7 @@ import javax.swing.JOptionPane;
 import javax.swing.table.DefaultTableModel;
 
 import com.kathsoft.kathpos.app.model.categoria.Categoria;
+import com.kathsoft.kathpos.app.model.viewmodel.SpResponseModel;
 import com.kathsoft.kathpos.tools.Conexion;
 
 public class CategoriaController implements Serializable {
@@ -42,74 +43,63 @@ public class CategoriaController implements Serializable {
 	 */
 	public Vector<Object[]> verCategoriasEnTabla(String nombre) {
 
-		ResultSet rset = null;
-		CallableStatement stm = null;
 		var data = new Vector<Object[]>();
 
-		try {
-			cn = Conexion.establecerConexionLocal("Kath_erp");
-			stm = cn.prepareCall("CALL ver_marcas(?)");
-			stm.setString(1, nombre);
-			rset = stm.executeQuery();
+		try (
+				Connection cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
+				CallableStatement stm = cn.prepareCall("CALL listCategoriaProducto(?);")
+		) {
 
-			while (rset.next()) {
-				data.add(new Object[] { rset.getInt(1), // indice
-						rset.getString(2), // nombre
-						rset.getString(3), // descripcion
-						rset.getShort(4) == 1 ? "Activo" : "Inactivo" });
+			stm.setString("p_nombre_categoria", nombre);
+
+			try (ResultSet rset = stm.executeQuery()) {
+
+				while (rset.next()) {
+					data.add(new Object[] {
+							rset.getInt("id_categoria"),
+							rset.getString("nombre"),
+							rset.getString("descripcion"),
+							rset.getShort("activo") == 1 ? "Activo" : "Inactivo"
+					});
+				}
+
 			}
-			
-			return data;
+
 		} catch (SQLException er) {
-			er.printStackTrace();
-			return null;
-		} finally {
-			try {
-				Conexion.cerrarConexion(cn, rset, stm);
-			} catch (SQLException er) {
-				er.printStackTrace();
-			} catch (Exception e) {
-				e.printStackTrace();
-			}
+			er.printStackTrace(System.err);
+		} catch (Exception er) {
+			er.printStackTrace(System.err);
 		}
+
+		return data;
 	}
 
 	public Vector<Categoria> obtenerIndicesDeCategorias() {
 
-		ResultSet rset = null;
-		CallableStatement stm = null;
 		var categorias = new Vector<Categoria>();
 		
-		
-		try {
-
-			cn = Conexion.establecerConexionLocal("Kath_erp");
-			stm = cn.prepareCall("CALL ver_nombres_categorias()");
-			rset = stm.executeQuery();
+		try (
+				Connection cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
+				CallableStatement stm = cn.prepareCall("CALL listCmbCategoriaProducto();");
+				ResultSet rset = stm.executeQuery()
+		) {
 
 			while (rset.next()) {
-				categorias.add(new Categoria(rset.getInt(1),rset.getString(2)));
+				categorias.add(new Categoria(
+						rset.getInt("id_categoria"),
+						rset.getString("nombre")
+				));
 			}
-			
-			return categorias;
 			
 		} catch (SQLException er) {
 			er.printStackTrace();
 			JOptionPane.showMessageDialog(null, er.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
-			return null;
 		} catch (Exception er) {
 			er.printStackTrace();
 			JOptionPane.showMessageDialog(null, er.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
-			return null;
-		} finally {
-			try {
-				Conexion.cerrarConexion(cn, rset, stm);
-			} catch (SQLException er) {
-				er.printStackTrace();
-			} catch (Exception e) {
-				e.printStackTrace();
-			}
 		}
+
+		return categorias;
 	}
 
 	/**
@@ -117,140 +107,172 @@ public class CategoriaController implements Serializable {
 	 * @param txa
 	 */
 	public void buscarCategoriaPorNombre(String nombre, DefaultTableModel model) {
-		CallableStatement stm = null;
-		ResultSet rset = null;
 
-		try {
+		try (
+				Connection cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
+				CallableStatement stm = cn.prepareCall("CALL listCategoriaProducto(?);")
+		) {
 
-			cn = Conexion.establecerConexionLocal("Kath_erp");
-			stm = cn.prepareCall("CALL buscar_categoria_por_nombre(?)");
-			stm.setString(1, nombre);
+			stm.setString("p_nombre_categoria", nombre);
 
-			rset = stm.executeQuery();
+			try (ResultSet rset = stm.executeQuery()) {
 
-			while (rset.next()) {
-				model.addRow(new Object[] { rset.getInt(1), // indice
-						rset.getString(2), // Nombre
-						rset.getString(3), // Descripcion
-						rset.getShort(4) == 1 ? "Activo" : "Inactivo" // Estatus
-				});
+				while (rset.next()) {
+					model.addRow(new Object[] {
+							rset.getInt("id_categoria"),
+							rset.getString("nombre"),
+							rset.getString("descripcion"),
+							rset.getShort("activo") == 1 ? "Activo" : "Inactivo"
+					});
+				}
+
 			}
 
 		} catch (SQLException er) {
-			er.printStackTrace();
+			er.printStackTrace(System.err);
 		} catch (Exception er) {
-			er.printStackTrace();
-		} finally {
-			try {
-				Conexion.cerrarConexion(cn, rset, stm);
-			} catch (SQLException er) {
-				er.printStackTrace();
-			} catch (Exception e) {
-				e.printStackTrace();
-			}
+			er.printStackTrace(System.err);
 		}
 	}
 
-	public void insertarNuevaCategoria(Categoria categoria) {
+	public SpResponseModel insertarNuevaCategoria(Categoria categoria) {
 
-		CallableStatement stm = null;
+		try (
+				Connection cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
+				CallableStatement stm = cn.prepareCall("CALL insertCategoriaProducto(?, ?);")
+		) {
 
-		try {
+			stm.setString("p_nombre", categoria.getNombre());
+			stm.setString("p_descripcion", categoria.getDescripcion());
 
-			cn = Conexion.establecerConexionLocal("kath_erp");
-			stm = cn.prepareCall("CALL insert_nva_categoria(?,?);");
-			stm.setString(1, categoria.getNombre());
-			stm.setString(2, categoria.getDescripcion());
-			stm.execute();
+			if (stm.execute()) {
+
+				try (ResultSet rset = stm.getResultSet()) {
+
+					if (rset != null && rset.next()) {
+						return new SpResponseModel(
+								rset.getInt("id"),
+								rset.getString("message")
+						);
+					}
+
+				}
+
+			}
+
+			return new SpResponseModel(500, "Ocurrio un error desconocido");
 
 		} catch (SQLException er) {
-			er.printStackTrace();
+			er.printStackTrace(System.err);
+			return new SpResponseModel(500, er.getMessage());
 		} catch (Exception er) {
-			er.printStackTrace();
-		} finally {
-			try {
-				Conexion.cerrarConexion(cn, stm);
-			} catch (SQLException er) {
-				er.printStackTrace();
-			} catch (Exception e) {
-				e.printStackTrace();
-			}
+			er.printStackTrace(System.err);
+			return new SpResponseModel(500, er.getMessage());
 		}
 	}
 
-	public void actualizarCategoria(Categoria categoria) {
-		CallableStatement stm = null;
+	public SpResponseModel actualizarCategoria(Categoria categoria) {
 
-		try {
+		try (
+				Connection cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
+				CallableStatement stm = cn.prepareCall("CALL updateCategoriaProducto(?, ?, ?, ?);")
+		) {
 
-			cn = Conexion.establecerConexionLocal("kath_erp");
-			stm = cn.prepareCall("CALL update_categoria(?,?,?);");
-			stm.setInt(1, categoria.getIdCategoria());
-			stm.setString(2, categoria.getNombre());
-			stm.setString(3, categoria.getDescripcion());
-			stm.execute();
+			stm.setInt("p_id_categoria", categoria.getIdCategoria());
+			stm.setString("p_nombre", categoria.getNombre());
+			stm.setString("p_descripcion", categoria.getDescripcion());
+			stm.setBoolean("p_activo", categoria.isActivo());
+
+			if (stm.execute()) {
+
+				try (ResultSet rset = stm.getResultSet()) {
+
+					if (rset != null && rset.next()) {
+						return new SpResponseModel(
+								rset.getInt("id"),
+								rset.getString("message")
+						);
+					}
+
+				}
+
+			}
+
+			return new SpResponseModel(500, "Ocurrio un error desconocido");
 
 		} catch (SQLException er) {
-			er.printStackTrace();
+			er.printStackTrace(System.err);
+			return new SpResponseModel(500, er.getMessage());
 		} catch (Exception er) {
-			er.printStackTrace();
-		} finally {
-			try {
-				Conexion.cerrarConexion(cn, stm);
-			} catch (SQLException er) {
-				er.printStackTrace();
-			} catch (Exception er) {
-				er.printStackTrace();
-			}
+			er.printStackTrace(System.err);
+			return new SpResponseModel(500, er.getMessage());
 		}
-
 	}
 
-	public void eliminarCategoria(int id) throws SQLException {
-		CallableStatement stm = null;
+	public SpResponseModel eliminarCategoria(int id) {
 
-		cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
-		stm = cn.prepareCall("CALL eliminar_categoria(?)");
-		stm.setInt(1, id);
-		stm.execute();
+		try (
+				Connection cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
+				CallableStatement stm = cn.prepareCall("CALL deleteCategoriaProducto(?);")
+		) {
 
-		Conexion.cerrarConexion(cn, stm);
+			stm.setInt("p_id_categoria", id);
 
+			if (stm.execute()) {
+
+				try (ResultSet rset = stm.getResultSet()) {
+
+					if (rset != null && rset.next()) {
+						return new SpResponseModel(
+								rset.getInt("id"),
+								rset.getString("message")
+						);
+					}
+
+				}
+
+			}
+
+			return new SpResponseModel(500, "Ocurrio un error desconocido");
+
+		} catch (SQLException er) {
+			er.printStackTrace(System.err);
+			return new SpResponseModel(500, er.getMessage());
+		} catch (Exception er) {
+			er.printStackTrace(System.err);
+			return new SpResponseModel(500, er.getMessage());
+		}
 	}
 
 	public Categoria buscarCategoriaPorId(int id) {
-		var categoria = new Categoria();
-		CallableStatement stm = null;
-		ResultSet rset = null;
-		try {
 
-			cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
-			stm = cn.prepareCall("CALL buscar_categoria_por_indice(?);");
-			stm.setInt(1, id);
-			rset = stm.executeQuery();
+		try (
+				Connection cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
+				CallableStatement stm = cn.prepareCall("CALL getCategoriaById(?);")
+		) {
 
-			if (rset.next()) {
-				categoria.setIdCategoria(rset.getInt(1));
-				categoria.setNombre(rset.getString(2));
-				categoria.setDescripcion(rset.getString(3));
-				categoria.setActivo(rset.getBoolean(4));
+			stm.setInt("p_id_categoria", id);
+
+			try (ResultSet rset = stm.executeQuery()) {
+
+				if (rset.next()) {
+					var categoria = new Categoria();
+					categoria.setIdCategoria(rset.getInt("id_categoria"));
+					categoria.setNombre(rset.getString("nombre"));
+					categoria.setDescripcion(rset.getString("descripcion"));
+					categoria.setActivo(rset.getBoolean("activo"));
+					return categoria;
+				}
+
 			}
 
-			return categoria;
 		} catch (SQLException er) {
-			er.printStackTrace();
-			return null;
+			er.printStackTrace(System.err);
 		} catch (Exception er) {
-			er.printStackTrace();
-			return null;
-		} finally {
-			try {
-				Conexion.cerrarConexion(cn, rset, stm);
-			} catch (SQLException e) {
-				e.printStackTrace();
-			}
+			er.printStackTrace(System.err);
 		}
 
+		return null;
 	}
 
 }


### PR DESCRIPTION
# Summary:

Este pull request actualiza `CategoriaController` para consumir los nuevos procedimientos almacenados del módulo de categorías de producto.

## Principales cambios:

- Se actualizó `verCategoriasEnTabla(String nombre)` para consumir `listCategoriaProducto`.
- Se actualizó `obtenerIndicesDeCategorias()` para consumir `listCmbCategoriaProducto`.
- Se actualizó `buscarCategoriaPorNombre(String nombre, DefaultTableModel model)` para usar `listCategoriaProducto`.
- Se actualizó `insertarNuevaCategoria(Categoria categoria)` para consumir `insertCategoriaProducto`.
- Se actualizó `actualizarCategoria(Categoria categoria)` para consumir `updateCategoriaProducto`.
- Se actualizó `eliminarCategoria(int id)` para consumir `deleteCategoriaProducto`.
- Se actualizó `buscarCategoriaPorId(int id)` para consumir `getCategoriaById`.
- Se reemplazó el mapeo por índices numéricos en los métodos actualizados por mapeo usando nombres de columnas.
- Se reemplazó el mapeo de parámetros por posición por nombres de parámetros.
- Se implementó `try-with-resources` en las consultas y operaciones actualizadas.
- Las operaciones de inserción, actualización y eliminación ahora retornan `SpResponseModel` con `id` y `message`.

## Correcciones:

- Se elimina el uso de procedimientos anteriores como `ver_marcas`, `insert_nva_categoria`, `update_categoria`, `eliminar_categoria` y `buscar_categoria_por_indice` dentro del controlador.
- Se estandariza el acceso a la base de datos usando `Conexion.DATA_BASE`.
- Se conserva el retorno `Vector<Object[]>` para integración con tablas existentes.
- Se conserva el retorno `Vector<Categoria>` para carga de combos.
- Se mantiene el cambio limitado a `CategoriaController`.