### PR TITLE
Fix: corrige columnas de articulos

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/view/articulo/PanelArticulos.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/articulo/PanelArticulos.java
@@ -26,6 +26,7 @@ import com.kathsoft.kathpos.app.model.articulo.CriterioOrdenamientoArticulo;
 import com.kathsoft.kathpos.app.model.viewmodel.JComboboxDataViewModel;
 import com.kathsoft.kathpos.app.view.Fr_principal;
 import com.kathsoft.kathpos.tools.AppContext;
+import com.kathsoft.kathpos.tools.ConstantsConllections;
 import com.kathsoft.kathpos.tools.DataTools;
 import com.kathsoft.kathpos.tools.MessageHandler;
 
@@ -283,14 +284,14 @@ public class PanelArticulos extends JPanel {
 		this.modelTablaArticulos.addColumn("Categoría");
 		this.modelTablaArticulos.addColumn("Código");
 		this.modelTablaArticulos.addColumn("Nombre");
-		this.modelTablaArticulos.addColumn("Impuesto");
-		this.modelTablaArticulos.addColumn("Costo");
+		this.modelTablaArticulos.addColumn("Exento");
+		this.modelTablaArticulos.addColumn("Costo Unitario");
 		this.modelTablaArticulos.addColumn("Precio");
 		this.modelTablaArticulos.addColumn("Existencia");
-		this.modelTablaArticulos.addColumn("Estatus");
+		this.modelTablaArticulos.addColumn("Activo");
 
 		DataTools.definirTamanioDeColumnas(
-				new int[] { 60, 180, 140, 120, 220, 90, 90, 90, 90, 90 },
+				ConstantsConllections.tablaArticulosColumnsWidth,
 				this.tablaArticulos
 		);
 	}

--- a/src/main/java/com/kathsoft/kathpos/tools/ConstantsConllections.java
+++ b/src/main/java/com/kathsoft/kathpos/tools/ConstantsConllections.java
@@ -29,18 +29,16 @@ public class ConstantsConllections implements java.io.Serializable{
 	};
 	
 	// Array que define el ancho de cada columna de la tabla de Articulos
-	public static final int[] tablaArticulosColumnsWidth = { 40, /* id */
-			150, /* codigo */
-			200, /* proveedor */
-			180, /* categoría */
-			100, /* codigo sat */
-			300, /* Nombre */
-			450, /* descripcion */
-			100, /* Existencia */
-			100, /* Precio G */
-			100, /* Precio E */
-			100, /* Despues de */
-			100 /* activo o inactivo */
+	public static final int[] tablaArticulosColumnsWidth = { 40, // id
+			200, // proveedor
+			180, // categoria
+			150, // codigo articulo
+			300, // nombre
+			90, // es exento
+			120, // costo unitario
+			120, // precio
+			100, // existencia
+			100 // activo
 	};
 	
 	// Array que define el ancho de cada columna de la tabla de empleados


### PR DESCRIPTION
# Summary:

Este pull request corrige el `DefaultTableModel` de `PanelArticulos` para que coincida con las columnas reales retornadas por el procedimiento almacenado `listArticulos`.

## Principales cambios:

- Se ajustaron las columnas configuradas en `setDefaultTableModel()` para reflejar la respuesta del SP.
- Se conserva el orden de columnas esperado por `ArticuloController.verArticulosEnTabla(...)`.
- Se reemplazó el arreglo local de anchos por `ConstantsConllections.tablaArticulosColumnsWidth`.
- Se actualizó `tablaArticulosColumnsWidth` para que tenga exactamente 10 posiciones, una por cada columna devuelta por `listArticulos`.

## Columnas configuradas:

- `Id`
- `Proveedor`
- `Categoría`
- `Código`
- `Nombre`
- `Exento`
- `Costo Unitario`
- `Precio`
- `Existencia`
- `Activo`

## Correspondencia con el procedimiento almacenado:

El modelo de tabla queda alineado con la respuesta del SP:

- `id_articulo`
- `nombre_proveedor`
- `nombre_categoria`
- `codigo_articulo`
- `nombre`
- `es_exento`
- `costo_unitario`
- `precio`
- `existencia`
- `activo`

## Archivos modificados:

- `src/main/java/com/kathsoft/kathpos/app/view/articulo/PanelArticulos.java`
- `src/main/java/com/kathsoft/kathpos/tools/ConstantsConllections.java`

## Reglas respetadas:

- No se modificó la distribución de componentes.
- No se modificó el layout.
- No se modificó la posición de los componentes dentro de `panelArticulosCentral`.