### PR TITLE
Fix: implementa eliminacion de articulos

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/view/articulo/PanelArticulos.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/articulo/PanelArticulos.java
@@ -265,7 +265,35 @@ public class PanelArticulos extends JPanel {
 	}
 
 	private void eliminarArticulo() {
+		if (this.tablaArticulos.getSelectedRow() < 0) {
+			MessageHandler.displayMessage(MessageHandler.WARN_MESSAGE, this, "Seleccione un articulo para eliminar");
+			return;
+		}
 
+		int idArticulo = DataTools.getIndiceElementoSeleccionado(
+				this.tablaArticulos,
+				this.modelTablaArticulos,
+				0
+		);
+
+		if (idArticulo < 0) {
+			return;
+		}
+
+		int option = MessageHandler.displayMessage(MessageHandler.DELETE_DATA_QUESTION_MESSAGE, this, " seleccionado?");
+
+		if (option != 0) {
+			return;
+		}
+
+		try {
+			AppContext.articuloController.eliminarArticulo(idArticulo);
+			MessageHandler.displayMessage(MessageHandler.DELETE_SUCCESS_MESSAGE, this, "");
+			this.llenarTablaArticulos();
+		} catch (Exception er) {
+			er.printStackTrace(System.err);
+			MessageHandler.displayMessage(MessageHandler.ERROR_MESSAGE, this, er.getMessage());
+		}
 	}
 
 	public void exportarArticuloExcel() {


### PR DESCRIPTION
# Summary:

Este pull request implementa la acción de eliminación de artículos desde `PanelArticulos`, siguiendo la mecánica usada en los demás módulos del sistema.

## Principales cambios:

- Se implementó `eliminarArticulo()` en `PanelArticulos`.
- Se valida que exista una fila seleccionada antes de intentar eliminar.
- Se obtiene el `id_articulo` desde la columna `Id` de la tabla usando `DataTools.getIndiceElementoSeleccionado(...)`.
- Se solicita confirmación al usuario usando `MessageHandler.DELETE_DATA_QUESTION_MESSAGE`.
- Se invoca `AppContext.articuloController.eliminarArticulo(idArticulo)` para ejecutar la eliminación.
- Se muestra mensaje de éxito mediante `MessageHandler.DELETE_SUCCESS_MESSAGE`.
- Se muestran advertencias y errores mediante `MessageHandler`.
- Se actualiza la tabla después de una eliminación exitosa llamando `llenarTablaArticulos()`.

## Archivo modificado:

- `src/main/java/com/kathsoft/kathpos/app/view/articulo/PanelArticulos.java`

## Reglas respetadas:

- No se modificó el layout.
- No se modificó la distribución de componentes.
- No se modificó la posición de los componentes dentro de `panelArticulosCentral`.
- El cambio queda limitado a la acción de eliminación y al refresco de tabla posterior.