### PR TITLE
fix(articulos): llena combos de proveedor y categoria

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/controller/CategoriaController.java
+++ b/src/main/java/com/kathsoft/kathpos/app/controller/CategoriaController.java
@@ -11,31 +11,14 @@ import javax.swing.JOptionPane;
 import javax.swing.table.DefaultTableModel;
 
 import com.kathsoft.kathpos.app.model.categoria.Categoria;
+import com.kathsoft.kathpos.app.model.viewmodel.JComboboxDataViewModel;
 import com.kathsoft.kathpos.app.model.viewmodel.SpResponseModel;
 import com.kathsoft.kathpos.tools.Conexion;
 
 public class CategoriaController implements Serializable {
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 6835247986143695345L;
-	
 
-	/*public void setCategoria(Categoria categoria) {
-		this.categoria = categoria;
-	}
-
-	public Categoria getCategoria() {
-		return this.categoria;
-	}*/
-
-	/**
-	 * conecta a la base de datos e imprime en un JTable de un formulario todos los
-	 * datos recolectados.
-	 * 
-	 * @param tabla
-	 */
 	public Vector<Object[]> verCategoriasEnTabla(String nombre) {
 
 		var data = new Vector<Object[]>();
@@ -69,9 +52,9 @@ public class CategoriaController implements Serializable {
 		return data;
 	}
 
-	public Vector<Categoria> obtenerIndicesDeCategorias() {
+	public Vector<JComboboxDataViewModel> obtenerIndicesDeCategorias() {
 
-		var categorias = new Vector<Categoria>();
+		var categorias = new Vector<JComboboxDataViewModel>();
 		
 		try (
 				Connection cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
@@ -80,7 +63,7 @@ public class CategoriaController implements Serializable {
 		) {
 
 			while (rset.next()) {
-				categorias.add(new Categoria(
+				categorias.add(new JComboboxDataViewModel(
 						rset.getInt("id_categoria"),
 						rset.getString("nombre")
 				));
@@ -97,10 +80,6 @@ public class CategoriaController implements Serializable {
 		return categorias;
 	}
 
-	/**
-	 * @param txf
-	 * @param txa
-	 */
 	public void buscarCategoriaPorNombre(String nombre, DefaultTableModel model) {
 
 		try (

--- a/src/main/java/com/kathsoft/kathpos/app/controller/ProveedorController.java
+++ b/src/main/java/com/kathsoft/kathpos/app/controller/ProveedorController.java
@@ -11,26 +11,15 @@ import javax.swing.JOptionPane;
 
 import com.kathsoft.kathpos.app.model.proveedor.Proveedor;
 import com.kathsoft.kathpos.app.model.proveedor.ProveedorById;
+import com.kathsoft.kathpos.app.model.viewmodel.JComboboxDataViewModel;
 import com.kathsoft.kathpos.app.model.viewmodel.SpResponseModel;
 import com.kathsoft.kathpos.tools.Conexion;
 
 public class ProveedorController implements java.io.Serializable {
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = -5820147766336769662L;
-	/**
-	 * 
-	 * 
-	 * 
-	 */
 	private static Connection cn = null;
 
-	/**
-	 * 
-	 * @param tabla
-	 */
 	public Vector<Object[]> verProveedoresEnTabla(String nombre) {
 
 		var data = new Vector<Object[]>();
@@ -107,13 +96,6 @@ public class ProveedorController implements java.io.Serializable {
 
 	}
 
-	/**
-	 * consulta la tabla de proveedores en la base de datos el listado completo de
-	 * proveedores registrados y extrae el RFC correspondiente agregandolo al
-	 * ComboBox que se le pasa como parámetro
-	 * 
-	 * @param cmb
-	 */
 	public void consultarRFCProveedor(JComboBox<String> cmb) {
 
 		CallableStatement stm = null;
@@ -147,23 +129,23 @@ public class ProveedorController implements java.io.Serializable {
 
 	}
 
-	public Vector<Proveedor> consultarNombresProveedor() {
+	public Vector<JComboboxDataViewModel> consultarNombresProveedor() {
 		
-		var data = new Vector<Proveedor>();
+		var data = new Vector<JComboboxDataViewModel>();
 		CallableStatement stm = null;
 		ResultSet rset = null;
 
 		try {
 
-			cn = Conexion.establecerConexionLocal("kath_erp");
-			stm = cn.prepareCall("CALL ver_nombres_proveedor();");
+			cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
+			stm = cn.prepareCall("CALL listCmbProveeodor();");
 			rset = stm.executeQuery();
 
 			while (rset.next()) {
-				var prov = new Proveedor();
-				prov.setIdProveedor(rset.getInt(1));
-				prov.setNombre(rset.getString(2));
-				data.add(prov);
+				data.add(new JComboboxDataViewModel(
+						rset.getInt("id"),
+						rset.getString("nombre")
+				));
 			}
 			
 			return data;
@@ -187,12 +169,6 @@ public class ProveedorController implements java.io.Serializable {
 
 	}
 
-	/**
-	 * inserta un nuevo registro en la base de datos
-	 * 
-	 * @param prv
-	 * @throws Exception
-	 */
 	public SpResponseModel insertarNuevoProveedor(Proveedor prv) {
 
 		try (
@@ -283,12 +259,6 @@ public class ProveedorController implements java.io.Serializable {
 
 	}
 
-	/**
-	 * 
-	 * @param rfc
-	 * @throws Exception
-	 * @throws SQLException
-	 */
 	public Proveedor buscarProveedorPorRFC(String rfc) throws Exception, SQLException {
 
 		Proveedor prv = new Proveedor();

--- a/src/main/java/com/kathsoft/kathpos/app/view/articulo/Fr_DatosArticulo.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/articulo/Fr_DatosArticulo.java
@@ -2,54 +2,38 @@ package com.kathsoft.kathpos.app.view.articulo;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.awt.Component;
-import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.GridLayout;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.KeyAdapter;
-import java.awt.event.KeyEvent;
 import java.math.BigDecimal;
-import java.sql.SQLException;
 import java.util.Vector;
 
-import javax.swing.ButtonGroup;
 import javax.swing.GroupLayout;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
-import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
-import javax.swing.JList;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
-import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.LayoutStyle.ComponentPlacement;
-import javax.swing.border.CompoundBorder;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.LineBorder;
 import javax.swing.border.TitledBorder;
 import javax.swing.table.DefaultTableModel;
-
-import com.kathsoft.kathpos.app.controller.ArticuloController;
-import com.kathsoft.kathpos.app.controller.CategoriaController;
-import com.kathsoft.kathpos.app.controller.ProveedorController;
-import com.kathsoft.kathpos.app.model.articulo.Articulo;
-import com.kathsoft.kathpos.app.model.categoria.Categoria;
-import com.kathsoft.kathpos.app.model.cliente.TipoCliente;
-import com.kathsoft.kathpos.app.model.proveedor.Proveedor;
-import com.kathsoft.kathpos.tools.AppContext;
-import com.kathsoft.kathpos.tools.ConstantsConllections;
-import com.kathsoft.kathpos.tools.DataTools;
-import com.kathsoft.kathpos.tools.MessageHandler;
 import javax.swing.GroupLayout.Alignment;
+
+import com.kathsoft.kathpos.app.model.articulo.Articulo;
+import com.kathsoft.kathpos.app.model.cliente.TipoCliente;
+import com.kathsoft.kathpos.app.model.viewmodel.JComboboxDataViewModel;
+import com.kathsoft.kathpos.tools.AppContext;
+import com.kathsoft.kathpos.tools.MessageHandler;
 
 public class Fr_DatosArticulo extends JFrame {
 
@@ -86,9 +70,9 @@ public class Fr_DatosArticulo extends JFrame {
 	private JTable tablePreciosPorTipoCliente;
 	private JButton btnConsultarExistencias;
 	private JLabel lblProveedor;
-	private JComboBox cmbProveedor;
+	private JComboBox<JComboboxDataViewModel> cmbProveedor;
 	private JLabel lblCategoria;
-	private JComboBox cmbCategoriaArticulo;
+	private JComboBox<JComboboxDataViewModel> cmbCategoriaArticulo;
 
 	public Fr_DatosArticulo(int tipoOperacion, int idArticulo, int sucursal) {
 		this.tipoOperacion = tipoOperacion;
@@ -117,7 +101,6 @@ public class Fr_DatosArticulo extends JFrame {
 		} else {
 			getArticuloPorId();
 		}
-		
 	}
 
 	private void buildHeader() {
@@ -133,8 +116,6 @@ public class Fr_DatosArticulo extends JFrame {
 
 	private void buildCentralForm() {
 	}
-
-	
 
 	private void buildFooter() {
 		panelInferiorBotones = new JPanel(new FlowLayout(FlowLayout.RIGHT));
@@ -213,11 +194,11 @@ public class Fr_DatosArticulo extends JFrame {
 		
 		this.lblProveedor = new JLabel("Proveedor");
 		
-		this.cmbProveedor = new JComboBox();
+		this.cmbProveedor = new JComboBox<JComboboxDataViewModel>();
 		
 		this.lblCategoria = new JLabel("Categoria");
 		
-		this.cmbCategoriaArticulo = new JComboBox();
+		this.cmbCategoriaArticulo = new JComboBox<JComboboxDataViewModel>();
 		GroupLayout gl_panelCentralFormulario = new GroupLayout(this.panelCentralFormulario);
 		gl_panelCentralFormulario.setHorizontalGroup(
 			gl_panelCentralFormulario.createParallelGroup(Alignment.TRAILING)
@@ -324,8 +305,6 @@ public class Fr_DatosArticulo extends JFrame {
 	}
 
 	private boolean validarCamposVacios() {
-		
-
 		return true;
 	}
 
@@ -337,13 +316,14 @@ public class Fr_DatosArticulo extends JFrame {
 		return new Articulo();
 	}
 
-	private void setDefaultTableModelPrecios() {		
-
+	private void setDefaultTableModelPrecios() {
+		modelTablaPrecios = new DefaultTableModel();
 		modelTablaPrecios.addColumn("Id Tipo Cliente");
 		modelTablaPrecios.addColumn("Tipo Cliente");
 		modelTablaPrecios.addColumn("Precio");
 		modelTablaPrecios.addColumn("Precio Especial");
 		modelTablaPrecios.addColumn("Cantidad Precio Especial");
+		this.tablePreciosPorTipoCliente.setModel(modelTablaPrecios);
 	}
 
 	private void llenarTablaPrecios() {
@@ -373,19 +353,24 @@ public class Fr_DatosArticulo extends JFrame {
 		}
 	}
 
-	
-
 	private void guardarPreciosArticulo() {
-		
-		// Pendiente: no existe SP para persistir precios_x_tipocliente en este repo.
+		// Pendiente: conectar envio de precios al controlador transaccional.
 	}
 
 	private void llenarCmbProveedor() {
-		
+		this.cmbProveedor.removeAllItems();
+		Vector<JComboboxDataViewModel> proveedores = AppContext.proveedorController.consultarNombresProveedor();
+		for (JComboboxDataViewModel proveedor : proveedores) {
+			this.cmbProveedor.addItem(proveedor);
+		}
 	}
 
 	private void llenarCmbCategoria() {
-		
+		this.cmbCategoriaArticulo.removeAllItems();
+		Vector<JComboboxDataViewModel> categorias = AppContext.categoriaController.obtenerIndicesDeCategorias();
+		for (JComboboxDataViewModel categoria : categorias) {
+			this.cmbCategoriaArticulo.addItem(categoria);
+		}
 	}
 
 	public boolean isOperacionEjecutada() {


### PR DESCRIPTION
## Resumen

Se conectan los combos de proveedor y categoría en `Fr_DatosArticulo` usando `JComboboxDataViewModel` como modelo común para elementos seleccionables.

Esta PR mantiene la regla del proyecto: los controladores no ejecutan SQL directo; las consultas se hacen mediante procedimientos almacenados.

## Cambios realizados

### Fr_DatosArticulo

- Se tipó `cmbProveedor` como `JComboBox<JComboboxDataViewModel>`.
- Se tipó `cmbCategoriaArticulo` como `JComboBox<JComboboxDataViewModel>`.
- Se implementó `llenarCmbProveedor()` usando `AppContext.proveedorController.consultarNombresProveedor()`.
- Se implementó `llenarCmbCategoria()` usando `AppContext.categoriaController.obtenerIndicesDeCategorias()`.
- Se inicializó `modelTablaPrecios` antes de agregar columnas.
- Se asignó explícitamente el modelo a `tablePreciosPorTipoCliente`.

### CategoriaController

- Se actualizó `obtenerIndicesDeCategorias()` para retornar `Vector<JComboboxDataViewModel>`.
- El método consume el procedimiento almacenado:

```sql
CALL listCmbCategoriaProducto();
```

- El resultado se mapea con:

```java
new JComboboxDataViewModel(
    rset.getInt("id_categoria"),
    rset.getString("nombre")
)
```

### ProveedorController

- Se actualizó `consultarNombresProveedor()` para retornar `Vector<JComboboxDataViewModel>`.
- El método consume el nuevo procedimiento almacenado:

```sql
CALL listCmbProveeodor();
```

- El resultado se mapea con:

```java
new JComboboxDataViewModel(
    rset.getInt("id"),
    rset.getString("nombre")
)
```

## Archivos modificados

```text
src/main/java/com/kathsoft/kathpos/app/view/articulo/Fr_DatosArticulo.java
src/main/java/com/kathsoft/kathpos/app/controller/CategoriaController.java
src/main/java/com/kathsoft/kathpos/app/controller/ProveedorController.java
```

## Alcance

Esta PR deja cargados los combos de proveedor y categoría en el formulario de datos de artículo. No implementa todavía el guardado funcional del formulario ni la edición completa del artículo.

## Pendientes

- Implementar `buildArticulo()` usando los ids seleccionados desde los combos.
- Implementar `getArticuloPorId()` para seleccionar proveedor y categoría por id en modo edición.
- Implementar validaciones del formulario.
- Conectar el alta de artículo con el flujo transaccional del controlador.
- Corregir textos visibles pendientes: `Codigo SAT`, `Categoria`, `Descripcion`, `Excento`.
