### PR TITLE
Update global stock checks and table for articles

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/controller/ArticuloController.java
+++ b/src/main/java/com/kathsoft/kathpos/app/controller/ArticuloController.java
@@ -269,29 +269,27 @@ public class ArticuloController implements java.io.Serializable {
 
 	public void consultarExistenciasPorSucursal(int idArticulo, DefaultTableModel tabla) {
 
-		CallableStatement stm = null;
-		ResultSet rset = null;
-
-		try {
-			cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
-			stm = cn.prepareCall("CALL ver_existencias_articulo_sucursal(?);");
+		try (
+				Connection cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
+				CallableStatement stm = cn.prepareCall("CALL listExistenciaGlobalArticulo(?);")
+		) {
 			stm.setInt(1, idArticulo);
-			rset = stm.executeQuery();
 
-			while (rset.next()) {
-				Object[] fila = { rset.getString(1), rset.getInt(2) };
-				tabla.addRow(fila);
+			try (ResultSet rset = stm.executeQuery()) {
+				while (rset.next()) {
+					Object[] fila = {
+							rset.getInt("id_sucursar"),
+							rset.getString("nombre"),
+							rset.getString("direccion"),
+							rset.getInt("existencia")
+					};
+					tabla.addRow(fila);
+				}
 			}
 		} catch (SQLException er) {
-			er.printStackTrace();
+			er.printStackTrace(System.err);
 		} catch (Exception er) {
-			er.printStackTrace();
-		} finally {
-			try {
-				Conexion.cerrarConexion(cn, rset, stm);
-			} catch (SQLException er) {
-				er.printStackTrace();
-			}
+			er.printStackTrace(System.err);
 		}
 	}
 

--- a/src/main/java/com/kathsoft/kathpos/app/view/articulo/Fr_DatosArticulo.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/articulo/Fr_DatosArticulo.java
@@ -271,6 +271,7 @@ public class Fr_DatosArticulo extends JFrame {
 		contentPane.add(panelInferiorBotones, BorderLayout.SOUTH);
 
 		this.btnConsultarExistencias = new JButton("Existencias");
+		this.btnConsultarExistencias.addActionListener(e -> abrirExistenciasArticulo());
 		this.panelInferiorBotones.add(this.btnConsultarExistencias);
 
 		btnCancelar = new JButton("Cancelar");
@@ -290,6 +291,18 @@ public class Fr_DatosArticulo extends JFrame {
 			}
 		});
 		panelInferiorBotones.add(btnGuardar);
+	}
+
+	private void abrirExistenciasArticulo() {
+		if (this.idArticulo <= 0) {
+			MessageHandler.displayMessage(MessageHandler.WARN_MESSAGE, this,
+					"Debe seleccionar o guardar un articulo antes de consultar existencias");
+			return;
+		}
+
+		Fr_ExistenciasArticulos form = new Fr_ExistenciasArticulos(this.idArticulo);
+		form.setLocationRelativeTo(this);
+		form.setVisible(true);
 	}
 
 	private void getArticuloPorId() {

--- a/src/main/java/com/kathsoft/kathpos/app/view/articulo/Fr_ExistenciasArticulos.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/articulo/Fr_ExistenciasArticulos.java
@@ -30,7 +30,8 @@ public class Fr_ExistenciasArticulos extends JFrame {
 	 * Create the frame.
 	 */
 	public Fr_ExistenciasArticulos(int id_articulo) {
-		setBounds(100, 100, 480, 480);
+		setTitle("Existencias globales del articulo");
+		setBounds(100, 100, 720, 480);
 		contentPane = new JPanel();
 		contentPane.setBorder(new EmptyBorder(5, 5, 5, 5));
 
@@ -43,7 +44,9 @@ public class Fr_ExistenciasArticulos extends JFrame {
 		modelTablaExistencias = new DefaultTableModel();
 		tablaExistenciasArticulo = new JTable();
 		tablaExistenciasArticulo.setModel(modelTablaExistencias);
+		modelTablaExistencias.addColumn("Id Sucursal");
 		modelTablaExistencias.addColumn("Sucursal");
+		modelTablaExistencias.addColumn("Dirección");
 		modelTablaExistencias.addColumn("Existencia");
 		scrollPaneExistenciasArticulo.setViewportView(tablaExistenciasArticulo);
 


### PR DESCRIPTION
## Resumen

Se conecta el flujo de apertura del formulario `Fr_DatosArticulo` desde `PanelArticulos`, se habilita la consulta de artículos por id en modo edición y se actualiza el flujo de consulta de existencias globales del artículo usando el nuevo procedimiento almacenado `listExistenciaGlobalArticulo`.

Esta PR integra los cambios realizados sobre la rama `dev` para continuar el módulo de artículos y preparar el formulario para los siguientes pasos funcionales de alta, edición y manejo de existencias.

---

## Rama origen y destino

```text
Origen: dev
Destino: main
````

---

## Commits incluidos

```text
486f6c9 fix(articulos): consulta articulo al abrir formulario de edicion
93e3d6b fix(articulos): valida apertura de formulario de articulo
3f3c882 fix(articulos): consulta existencia global por articulo
03492ce fix(articulos): actualiza tabla de existencias globales
f378866 fix(articulos): abre existencias globales desde formulario
```

---

## Cambios realizados

### 1. Apertura del formulario de artículos desde `PanelArticulos`

Se ajustaron las llamadas del módulo principal de artículos hacia `Fr_DatosArticulo`.

El botón de agregar artículo ahora abre el formulario en modo alta:

```java
abrirVentanaFormularioArticulo(0, 0, this.sucursal.getIdSucursal());
```

El botón de actualizar artículo ahora valida primero que exista una fila seleccionada en `tablaArticulos`.

Después obtiene el `id_articulo` desde la columna `0` del `DefaultTableModel` y abre el formulario en modo edición:

```java
abrirVentanaFormularioArticulo(1, idArticulo, this.sucursal.getIdSucursal());
```

Esto permite que la edición parta directamente del elemento seleccionado en la tabla de artículos.

---

### 2. Validación para actualizar artículo

Se agregó validación antes de abrir el formulario en modo edición.

Si no hay artículo seleccionado, se muestra una advertencia y no se abre el formulario.

También se valida que el id obtenido desde la tabla sea válido antes de llamar a `Fr_DatosArticulo`.

Esto evita abrir el formulario de edición sin contexto o con un `id_articulo` inválido.

---

### 3. Estado interno en `Fr_DatosArticulo`

Se agregaron como campos internos del formulario:

```java
private final int idArticulo;
private final int idSucursal;
```

El constructor ahora conserva el artículo y la sucursal recibidos desde `PanelArticulos`.

Esto permite que el formulario tenga el contexto necesario para:

* consultar el artículo en modo edición;
* abrir el formulario de existencias del artículo;
* preparar los siguientes flujos de actualización.

---

### 4. Consulta del artículo por id en modo edición

Cuando `Fr_DatosArticulo` se abre en modo edición, ahora ejecuta:

```java
AppContext.articuloController.consultarArticuloPorId(this.idArticulo, this.idSucursal);
```

El resultado se carga en los campos del formulario:

```text
Código
Código SAT
Unidad SAT
Nombre
Descripción
Costo unitario
Indicador de IVA
Proveedor
Categoría
```

También se seleccionan proveedor y categoría en sus respectivos combos usando los ids devueltos por el procedimiento `getArticuloById`.

---

## Flujo de edición

```mermaid
flowchart TD
    A[Usuario selecciona artículo en tabla] --> B[Click en Actualizar]
    B --> C{¿Hay fila seleccionada?}
    C -->|No| D[Mostrar advertencia]
    C -->|Sí| E[Obtener id_articulo desde columna 0]
    E --> F{¿Id válido?}
    F -->|No| D
    F -->|Sí| G[Abrir Fr_DatosArticulo en modo edición]
    G --> H[consultarArticuloPorId]
    H --> I[CALL getArticuloById]
    I --> J[Cargar campos del formulario]
    J --> K[Seleccionar proveedor y categoría por id]
```

---

## 5. Actualización de consulta de existencias globales

Se actualizó el método existente en `ArticuloController`:

```java
public void consultarExistenciasPorSucursal(int idArticulo, DefaultTableModel tabla)
```

Ahora consume el nuevo procedimiento almacenado:

```sql
CALL listExistenciaGlobalArticulo(?);
```

El procedimiento devuelve la existencia del artículo en todas las sucursales registradas:

```text
id_sucursar
nombre
direccion
existencia
```

El controlador ahora mapea esos valores hacia el `DefaultTableModel`.

---

## 6. Actualización de `Fr_ExistenciasArticulos`

Se actualizó el `DefaultTableModel` del formulario de existencias para reflejar la nueva estructura del procedimiento almacenado.

Columnas anteriores:

```text
Sucursal
Existencia
```

Columnas actuales:

```text
Id Sucursal
Sucursal
Dirección
Existencia
```

Esto permite visualizar de forma más completa la existencia global de un artículo, incluyendo la sucursal y su dirección.

---

## 7. Conexión de `btnConsultarExistencias`

Se conectó el botón `btnConsultarExistencias` dentro de `Fr_DatosArticulo`.

El botón ahora abre `Fr_ExistenciasArticulos` usando el `idArticulo` actual del formulario.

Si el formulario no tiene un artículo válido, por ejemplo en modo alta antes de guardar, se muestra una advertencia y no se abre la ventana de existencias.

Esto evita consultar existencias de artículos que todavía no existen en base de datos.

---

## Flujo de consulta de existencias

```mermaid
flowchart TD
    A[Fr_DatosArticulo] --> B[Click en Existencias]
    B --> C{¿idArticulo válido?}
    C -->|No| D[Mostrar advertencia]
    C -->|Sí| E[Abrir Fr_ExistenciasArticulos]
    E --> F[consultarExistenciasPorSucursal]
    F --> G[CALL listExistenciaGlobalArticulo]
    G --> H[Obtener existencias por sucursal]
    H --> I[Llenar tabla]
```

---

## Archivos modificados

```text
src/main/java/com/kathsoft/kathpos/app/view/articulo/PanelArticulos.java
src/main/java/com/kathsoft/kathpos/app/view/articulo/Fr_DatosArticulo.java
src/main/java/com/kathsoft/kathpos/app/view/articulo/Fr_ExistenciasArticulos.java
src/main/java/com/kathsoft/kathpos/app/controller/ArticuloController.java
```

---

## Procedimientos almacenados utilizados

```sql
CALL getArticuloById(?);
```

Usado para cargar el artículo seleccionado en modo edición.

```sql
CALL listExistenciaGlobalArticulo(?);
```

Usado para consultar la existencia del artículo en todas las sucursales registradas.

---

## Alcance de esta PR

Esta PR deja conectados los siguientes flujos:

* apertura de formulario para alta de artículo;
* apertura de formulario para edición de artículo;
* validación de selección antes de editar;
* consulta del artículo por id al abrir en modo edición;
* carga de datos del artículo en el formulario;
* selección de proveedor y categoría por id;
* apertura del formulario de existencias desde `Fr_DatosArticulo`;
* consulta de existencias globales del artículo por sucursal.

---

## Pendientes

Quedan pendientes para las siguientes PRs:

* Implementar `buildArticulo()`.
* Implementar validaciones completas del formulario.
* Conectar `insertarNuevoArticulo()` con el flujo transaccional del controlador.
* Conectar `actualizarArticulo()` con el procedimiento almacenado correspondiente.
* Construir `List<PrecioTipoCliente>` desde la tabla de precios.
* Cargar precios reales por tipo de cliente en modo edición.
* Definir si la consulta de existencias debe quedar disponible solo en modo edición.

```
```
