### PR TITLE
fix(articulos): restringe edicion de tabla de precios

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/view/articulo/Fr_DatosArticulo.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/articulo/Fr_DatosArticulo.java
@@ -363,7 +363,14 @@ public class Fr_DatosArticulo extends JFrame {
 	}
 
 	private void setDefaultTableModelPrecios() {
-		this.modelTablaPrecios = new DefaultTableModel();
+		this.modelTablaPrecios = new DefaultTableModel() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public boolean isCellEditable(int row, int column) {
+				return column >= 2 && column <= 4;
+			}
+		};
 		this.modelTablaPrecios.addColumn("Id Tipo Cliente");
 		this.modelTablaPrecios.addColumn("Tipo Cliente");
 		this.modelTablaPrecios.addColumn("Precio");


### PR DESCRIPTION
## Resumen

Se restringe la edición de la tabla de precios por tipo de cliente en `Fr_DatosArticulo`.

La tabla conserva visibles todas sus columnas, pero únicamente permite editar las columnas destinadas a captura de precios.

## Cambios realizados

### Fr_DatosArticulo

Se modificó la creación de `modelTablaPrecios` para usar un `DefaultTableModel` con override de `isCellEditable(...)`.

Columnas no editables:

```text
0 - Id Tipo Cliente
1 - Tipo Cliente
```

Columnas editables:

```text
2 - Precio
3 - Precio Especial
4 - Cantidad Precio Especial
```

Implementación aplicada:

```java
this.modelTablaPrecios = new DefaultTableModel() {
    private static final long serialVersionUID = 1L;

    @Override
    public boolean isCellEditable(int row, int column) {
        return column >= 2 && column <= 4;
    }
};
```

## Archivo modificado

```text
src/main/java/com/kathsoft/kathpos/app/view/articulo/Fr_DatosArticulo.java
```

## Alcance

Esta PR solo modifica el comportamiento de edición del `JTable` de precios por tipo de cliente.

No cambia el flujo de guardado, consulta, actualización ni procedimientos almacenados.
