### PR TITLE
fix(articulos): valida valores numericos en tabla de precios

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/view/articulo/Fr_DatosArticulo.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/articulo/Fr_DatosArticulo.java
@@ -39,6 +39,7 @@ import com.kathsoft.kathpos.tools.MessageHandler;
 public class Fr_DatosArticulo extends JFrame {
 
 	private static final long serialVersionUID = -1528483064591725560L;
+	private static final Object VALOR_INVALIDO_TABLA = new Object();
 
 	private final int tipoOperacion;
 	private final int idArticulo;
@@ -370,6 +371,21 @@ public class Fr_DatosArticulo extends JFrame {
 			public boolean isCellEditable(int row, int column) {
 				return column >= 2 && column <= 4;
 			}
+
+			@Override
+			public void setValueAt(Object aValue, int row, int column) {
+				if (column >= 2 && column <= 4) {
+					Object valorNormalizado = normalizarValorPrecio(aValue, column);
+					if (valorNormalizado == VALOR_INVALIDO_TABLA) {
+						return;
+					}
+
+					super.setValueAt(valorNormalizado, row, column);
+					return;
+				}
+
+				super.setValueAt(aValue, row, column);
+			}
 		};
 		this.modelTablaPrecios.addColumn("Id Tipo Cliente");
 		this.modelTablaPrecios.addColumn("Tipo Cliente");
@@ -377,6 +393,57 @@ public class Fr_DatosArticulo extends JFrame {
 		this.modelTablaPrecios.addColumn("Precio Especial");
 		this.modelTablaPrecios.addColumn("Cantidad Precio Especial");
 		this.tablePreciosPorTipoCliente.setModel(this.modelTablaPrecios);
+	}
+
+	private Object normalizarValorPrecio(Object value, int column) {
+		switch (column) {
+		case 2:
+			return normalizarDecimalPrecio(value, true, "Precio");
+		case 3:
+			return normalizarDecimalPrecio(value, false, "Precio especial");
+		case 4:
+			return normalizarCantidadPrecioEspecial(value);
+		default:
+			return value;
+		}
+	}
+
+	private Object normalizarDecimalPrecio(Object value, boolean requerido, String campo) {
+		String text = value == null ? "" : String.valueOf(value).trim();
+		if (text.isEmpty()) {
+			if (requerido) {
+				mostrarAdvertenciaValorNumerico(campo);
+				return VALOR_INVALIDO_TABLA;
+			}
+
+			return null;
+		}
+
+		try {
+			return new BigDecimal(text.replace(',', '.'));
+		} catch (NumberFormatException er) {
+			mostrarAdvertenciaValorNumerico(campo);
+			return VALOR_INVALIDO_TABLA;
+		}
+	}
+
+	private Object normalizarCantidadPrecioEspecial(Object value) {
+		String text = value == null ? "" : String.valueOf(value).trim();
+		if (text.isEmpty()) {
+			return null;
+		}
+
+		try {
+			return Integer.valueOf(text);
+		} catch (NumberFormatException er) {
+			mostrarAdvertenciaValorNumerico("Cantidad precio especial");
+			return VALOR_INVALIDO_TABLA;
+		}
+	}
+
+	private void mostrarAdvertenciaValorNumerico(String campo) {
+		MessageHandler.displayMessage(MessageHandler.WARN_MESSAGE, this,
+				campo + " debe ser un valor numérico válido");
 	}
 
 	private void llenarTablaPrecios() {


### PR DESCRIPTION
## Resumen

Se agrega validación numérica en las columnas editables de la tabla de precios por tipo de cliente dentro de `Fr_DatosArticulo`.

Las dos primeras columnas continúan bloqueadas y las columnas de captura ahora rechazan valores no numéricos.

## Cambios realizados

### Fr_DatosArticulo

Se mantiene la restricción de edición de columnas:

```text
0 - Id Tipo Cliente: no editable
1 - Tipo Cliente: no editable
2 - Precio: editable
3 - Precio Especial: editable
4 - Cantidad Precio Especial: editable
```

Se agregó override de `setValueAt(...)` en el `DefaultTableModel` para validar y normalizar los valores antes de asignarlos al modelo.

Validaciones aplicadas:

```text
Precio                    -> decimal requerido
Precio Especial           -> decimal opcional
Cantidad Precio Especial  -> entero opcional
```

Si el usuario captura un valor inválido, se muestra advertencia y se conserva el valor anterior de la celda.

## Detalle técnico

- `Precio` y `Precio Especial` se normalizan como `BigDecimal`.
- `Cantidad Precio Especial` se normaliza como `Integer`.
- Se aceptan decimales con punto o coma; internamente se normaliza coma a punto.
- Las celdas opcionales permiten valor vacío y lo guardan como `null`.
- La columna `Precio` no permite vacío porque es el precio base por tipo de cliente.

## Archivo modificado

```text
src/main/java/com/kathsoft/kathpos/app/view/articulo/Fr_DatosArticulo.java
```

## Alcance

Esta PR solo modifica la validación de captura en la tabla de precios por tipo de cliente.

No cambia persistencia, procedimientos almacenados, alta, actualización ni consulta de artículos.
