### PR TITLE
fix(tipo-cliente): refresca tabla y filtra activos en precios

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/controller/TipoClienteController.java
+++ b/src/main/java/com/kathsoft/kathpos/app/controller/TipoClienteController.java
@@ -15,36 +15,7 @@ public class TipoClienteController {
 	private static Connection cn = null;
 
 	public Vector<TipoCliente> cmbTipoCliente() {
-
-		var data = new Vector<TipoCliente>();
-		CallableStatement stm = null;
-		ResultSet rset = null;
-
-		try {
-
-			cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
-			stm = cn.prepareCall("CALL cmb_tipoCliente");
-			rset = stm.executeQuery();
-
-			while (rset.next()) {
-				data.add(new TipoCliente(rset.getInt(1), rset.getString(2)));
-			}
-
-			return data;
-
-		} catch (SQLException er) {
-			er.printStackTrace();
-			return data;
-		} catch (Exception er) {
-			er.printStackTrace();
-			return data;
-		} finally {
-			try {
-				Conexion.cerrarConexion(cn, rset, stm);
-			} catch (Exception er) {
-				er.printStackTrace();
-			}
-		}
+		return this.listarTipoClienteActivosParaPrecios("");
 	}
 
 	public Vector<Object[]> listarTipoCliente(String nombre) {
@@ -84,6 +55,28 @@ public class TipoClienteController {
 			}
 		}
 
+	}
+
+	/**
+	 * Lista los tipos de cliente activos reutilizando la consulta general.
+	 * Se usa para capturar precios de artículos y evitar referencias a tipos inactivos.
+	 */
+	public Vector<TipoCliente> listarTipoClienteActivosParaPrecios(String nombre) {
+		var data = new Vector<TipoCliente>();
+		Vector<Object[]> tiposCliente = this.listarTipoCliente(nombre);
+
+		if (tiposCliente == null || tiposCliente.isEmpty()) {
+			return data;
+		}
+
+		for (Object[] row : tiposCliente) {
+			String status = String.valueOf(row[3]);
+			if ("Activo".equalsIgnoreCase(status)) {
+				data.add(new TipoCliente(Integer.parseInt(String.valueOf(row[0])), String.valueOf(row[1])));
+			}
+		}
+
+		return data;
 	}
 
 	public SpResponseModel insertarNuevoTipoCliente(TipoCliente data) {

--- a/src/main/java/com/kathsoft/kathpos/app/view/clientes/Fr_DatosTipoCliente.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/clientes/Fr_DatosTipoCliente.java
@@ -36,6 +36,7 @@ public class Fr_DatosTipoCliente extends JFrame {
 	 */
 	private int tipoOperacion;
 	private int idTipoCliente;
+	private boolean operacionEjecutada;
 	private JPanel contentPane;
 	private JPanel panelSuperiorEtiqueta;
 	private JLabel lblNewLabel;
@@ -192,7 +193,11 @@ public class Fr_DatosTipoCliente extends JFrame {
 				result.id() == 200 ?
 				MessageHandler.INSERT_SUCCESS_MESSAGE : MessageHandler.ERROR_MESSAGE, this, result.message());
 		
-		this.limpiarCampos();
+		if (result.id() == 200) {
+			this.operacionEjecutada = true;
+			this.limpiarCampos();
+			this.dispose();
+		}
 
 	}
 
@@ -229,11 +234,19 @@ public class Fr_DatosTipoCliente extends JFrame {
 				result.id() == 200 ?
 				MessageHandler.UPDATE_SUCCESS_MESSAGE : MessageHandler.ERROR_MESSAGE, this, result.message());
 
+		if (result.id() == 200) {
+			this.operacionEjecutada = true;
+			this.dispose();
+		}
 	}
 		
 
 	private boolean validarCamposVacios() {
 		return this.txfNombre.getText().isBlank() || this.txfDescripcion.getText().isBlank() ? true : false;
+	}
+
+	public boolean isOperacionEjecutada() {
+		return operacionEjecutada;
 	}
 
 	private void cerrarForm() {

--- a/src/main/java/com/kathsoft/kathpos/app/view/clientes/PanelTipoCliente.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/clientes/PanelTipoCliente.java
@@ -7,6 +7,9 @@ import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -240,6 +243,9 @@ public class PanelTipoCliente extends JPanel {
 				result.id() == 200 ?
 				MessageHandler.DELETE_SUCCESS_MESSAGE : MessageHandler.ERROR_MESSAGE, this, result.message());
 		
+		if (result.id() == 200) {
+			listarTipoClientes(this.txfNombreTipoCliente.getText());
+		}
 	}
 	
 	private void abrirFormTipoClientes(int opcion, int idTipoCliente) {
@@ -253,6 +259,14 @@ public class PanelTipoCliente extends JPanel {
 				try {
 					Fr_DatosTipoCliente frame = new Fr_DatosTipoCliente(opcion, idTipoCliente);
 					frame.setLocationRelativeTo(cmp);
+					frame.addWindowListener(new WindowAdapter() {
+						@Override
+						public void windowClosed(WindowEvent e) {
+							if (frame.isOperacionEjecutada()) {
+								listarTipoClientes(txfNombreTipoCliente.getText());
+							}
+						}
+					});
 					frame.setVisible(true);
 				} catch (Exception er) {
 					er.printStackTrace();


### PR DESCRIPTION
## Resumen

Se corrigen dos problemas relacionados con `TipoCliente`:

- La tabla del módulo de tipos de cliente ahora se refresca después de agregar, actualizar o eliminar un registro.
- La tabla de precios por tipo de cliente usada en `Fr_DatosArticulo` ahora solo toma tipos de cliente activos.

## Cambios realizados

### TipoClienteController

Se agrega el método:

```java
listarTipoClienteActivosParaPrecios(String nombre)
```

Este método reutiliza:

```java
listarTipoCliente(String nombre)
```

y filtra los registros cuyo estatus sea `Activo`.

Además, `cmbTipoCliente()` ahora delega en este nuevo método, por lo que las pantallas que cargan tipos de cliente para precios ya no reciben registros inactivos.

### Fr_DatosTipoCliente

Se agrega la bandera:

```java
operacionEjecutada
```

La bandera se marca como `true` únicamente cuando el SP responde con código `200` después de insertar o actualizar.

También se agrega:

```java
isOperacionEjecutada()
```

para que el panel padre pueda saber si debe actualizar la tabla.

### PanelTipoCliente

Se agrega un `WindowListener` al formulario de datos para refrescar la tabla cuando se cierre después de una operación exitosa.

También se refresca la tabla inmediatamente después de eliminar un tipo de cliente cuando la respuesta del controlador sea exitosa.

## Archivos modificados

```text
src/main/java/com/kathsoft/kathpos/app/controller/TipoClienteController.java
src/main/java/com/kathsoft/kathpos/app/view/clientes/Fr_DatosTipoCliente.java
src/main/java/com/kathsoft/kathpos/app/view/clientes/PanelTipoCliente.java
```

## Alcance

Esta PR no crea procedimientos almacenados nuevos.

La carga para precios de artículos reutiliza la consulta existente de tipos de cliente y aplica el filtro de activos en Java, tal como se solicitó.