### PR TITLE
feat(compras): conecta filtros iniciales en PanelCompras

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/view/compras/PanelCompras.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/compras/PanelCompras.java
@@ -4,12 +4,16 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.FlowLayout;
 import java.awt.Font;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.text.ParseException;
 
 import javax.swing.GroupLayout;
 import javax.swing.GroupLayout.Alignment;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
+import javax.swing.JFormattedTextField;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -17,10 +21,11 @@ import javax.swing.JTable;
 import javax.swing.JTextField;
 import javax.swing.LayoutStyle.ComponentPlacement;
 import javax.swing.table.DefaultTableModel;
+import javax.swing.text.MaskFormatter;
 
 import com.kathsoft.kathpos.app.model.compra.TipoCompraFiltro;
 import com.kathsoft.kathpos.app.model.viewmodel.JComboboxDataViewModel;
-import javax.swing.JFormattedTextField;
+import com.kathsoft.kathpos.tools.AppContext;
 
 public class PanelCompras extends JPanel {
 
@@ -131,7 +136,7 @@ public class PanelCompras extends JPanel {
 
 		this.lblProveedor = new JLabel("Proveedor");
 		this.cmbProveedor = new JComboBox<JComboboxDataViewModel>();
-		this.cmbProveedor.addItem(new JComboboxDataViewModel(0, "Todos"));
+		this.llenarCmbProveedor();
 
 		this.lblFechaFacturaInicio = new JLabel("Fecha factura inicio");
 
@@ -152,10 +157,19 @@ public class PanelCompras extends JPanel {
 
 		this.btnLimpiar = new JButton("Limpiar");
 		this.btnLimpiar.setBackground(new Color(176, 196, 222));
+		this.btnLimpiar.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				limpiarFiltros();
+			}
+		});
 		
-		this.formattedTextFieldFechaInicio = new JFormattedTextField();
+		this.formattedTextFieldFechaInicio = new JFormattedTextField(buildDateFormatter());
+		this.formattedTextFieldFechaInicio.setColumns(10);
+		this.formattedTextFieldFechaInicio.setToolTipText("dd/MM/yyyy");
 		
-		this.formattedTextFieldFechaFin = new JFormattedTextField();
+		this.formattedTextFieldFechaFin = new JFormattedTextField(buildDateFormatter());
+		this.formattedTextFieldFechaFin.setColumns(10);
+		this.formattedTextFieldFechaFin.setToolTipText("dd/MM/yyyy");
 
 		GroupLayout glPanelFiltros = new GroupLayout(this.panelFiltros);
 		glPanelFiltros.setHorizontalGroup(
@@ -229,10 +243,42 @@ public class PanelCompras extends JPanel {
 		this.modelTablaCompras.addColumn("Activo");
 	}
 
+	private void llenarCmbProveedor() {
+		this.cmbProveedor.removeAllItems();
+		this.cmbProveedor.addItem(new JComboboxDataViewModel(0, "Todos"));
+		AppContext.proveedorController.consultarNombresProveedor().forEach(this.cmbProveedor::addItem);
+	}
+
 	private void llenarCmbTipoCompra() {
 		this.cmbTipoCompra.removeAllItems();
 		for (TipoCompraFiltro tipoCompraFiltro : TipoCompraFiltro.values()) {
 			this.cmbTipoCompra.addItem(tipoCompraFiltro);
+		}
+	}
+
+	private MaskFormatter buildDateFormatter() {
+		try {
+			MaskFormatter formatter = new MaskFormatter("##/##/####");
+			formatter.setPlaceholderCharacter('_');
+			formatter.setValidCharacters("0123456789");
+			return formatter;
+		} catch (ParseException er) {
+			er.printStackTrace(System.err);
+			return null;
+		}
+	}
+
+	private void limpiarFiltros() {
+		this.txfFolioFactura.setText("");
+		this.formattedTextFieldFechaInicio.setValue(null);
+		this.formattedTextFieldFechaFin.setValue(null);
+
+		if (this.cmbProveedor.getItemCount() > 0) {
+			this.cmbProveedor.setSelectedIndex(0);
+		}
+
+		if (this.cmbTipoCompra.getItemCount() > 0) {
+			this.cmbTipoCompra.setSelectedIndex(0);
 		}
 	}
 


### PR DESCRIPTION
## Resumen

Esta PR integra `dev` hacia `main` con la construcción inicial del panel visual del módulo de compras y sus primeros filtros funcionales.

El alcance principal es dejar disponible `PanelCompras` como interfaz base del módulo, sin integrarlo todavía manualmente a `Fr_principal`, y preparar los controles necesarios para futuras búsquedas por proveedor, folio, rango de fecha factura y tipo de compra.

---

## Rama origen y destino

```text
Origen: dev
Destino: main
````

---

## Cambios principales

### 1. Nuevo `PanelCompras`

Se agrega el panel base del módulo de compras:

```text
src/main/java/com/kathsoft/kathpos/app/view/compras/PanelCompras.java
```

El panel sigue el patrón visual y técnico utilizado en otros módulos Swing del proyecto, como artículos, empleados y clientes.

Características principales:

```text
- clase basada en JPanel;
- layout principal BorderLayout;
- título en BorderLayout.NORTH;
- panel principal en BorderLayout.CENTER;
- panel central construido con GroupLayout;
- componentes declarados como atributos antes del constructor;
- componentes inicializados dentro del constructor;
- estructura compatible con WindowBuilder de Eclipse.
```

---

## 2. Layout principal del módulo

La estructura general de `PanelCompras` queda organizada de la siguiente forma:

```text
PanelCompras
├── BorderLayout.NORTH  -> panelTitulo
└── BorderLayout.CENTER -> panelPrincipalContenedor
```

El título visible del módulo es:

```text
Compras
```

---

## 3. Panel central con `GroupLayout`

El panel central `panelPrincipalContenedor` utiliza `GroupLayout` y contiene:

```text
- panelBotones;
- scrollPaneTablaCompras;
- panelFiltros.
```

Esto mantiene consistencia con la forma en que están construidos los paneles principales del sistema.

---

## 4. Botones base del módulo

Se agregan los botones visuales principales del módulo:

```text
Agregar
Actualizar
Eliminar
Exportar a Excel
Buscar
Limpiar
```

Por ahora solo se conecta funcionalmente el botón `Limpiar`.

Los demás botones quedan preparados visualmente para próximas iteraciones.

---

## 5. Tabla base de compras

Se agrega una tabla `JTable` con `DefaultTableModel` para preparar el listado de compras.

Columnas iniciales:

```text
Id
Empleado
Proveedor
Folio Factura
Fecha Factura
Fecha Compra
Tipo Compra
Subtotal
IVA
Total
Activo
```

---

## 6. Filtros visuales de búsqueda

Se agregan controles visuales para los criterios principales de búsqueda de compras:

```text
Proveedor
Folio factura
Fecha factura inicio
Fecha factura fin
Tipo compra
```

Estos filtros quedan preparados para conectarse posteriormente con `CompraController`.

---

## 7. Enum `TipoCompraFiltro`

Se agrega el enum:

```text
src/main/java/com/kathsoft/kathpos/app/model/compra/TipoCompraFiltro.java
```

Constantes incluidas:

```text
TODOS
CONTADO
CREDITO
```

Mapeo esperado:

```text
TODOS   -> null
CONTADO -> false
CREDITO -> true
```

Este enum permite manejar el filtro de tipo de compra mediante `JComboBox` sin depender de literales sueltos en la vista.

---

## 8. Formato de fechas en campos de filtro

Se asigna formato a los campos de fecha del panel:

```text
formattedTextFieldFechaInicio
formattedTextFieldFechaFin
```

Formato aplicado:

```text
##/##/####
```

Esto deja preparados los campos para capturar rangos de fecha factura.

---

## 9. Carga inicial del combo de proveedores

Se agrega la carga del combo de proveedores mediante:

```java
AppContext.proveedorController.consultarNombresProveedor()
```

El combo `cmbProveedor` se inicializa con:

```text
Todos
```

y posteriormente carga los proveedores activos disponibles desde el controlador existente.

---

## 10. Evento del botón `Limpiar`

Se agrega evento a `btnLimpiar`.

El método de limpieza restablece los filtros principales:

```text
Proveedor -> Todos
Folio factura -> vacío
Fecha factura inicio -> vacío
Fecha factura fin -> vacío
Tipo compra -> TODOS
```

Esto permite regresar el panel a su estado inicial de búsqueda.

---

## Archivos agregados o modificados

```text
src/main/java/com/kathsoft/kathpos/app/model/compra/TipoCompraFiltro.java
src/main/java/com/kathsoft/kathpos/app/view/compras/PanelCompras.java
```

---

## Alcance de esta PR

Esta PR incluye:

```text
- creación visual de PanelCompras;
- estructura base del módulo de compras;
- tabla base de compras;
- filtros visuales principales;
- enum TipoCompraFiltro;
- formato para campos de fecha;
- carga inicial del combo de proveedores;
- evento de limpieza de filtros.
```

---

## Fuera de alcance

Esta PR no incluye:

```text
- integración con Fr_principal;
- conexión del botón Buscar con CompraController;
- carga real de la tabla de compras;
- apertura de formulario de alta de compra;
- apertura de formulario de edición de compra;
- eliminación de compras;
- exportación real a Excel;
- validación completa de fechas;
- conexión directa con procedimientos almacenados del módulo de compras.
```

---

## Nota técnica

La integración con `Fr_principal` queda fuera de esta PR y será realizada manualmente para evitar modificar el archivo principal del sistema.

El panel queda listo para que, en una siguiente iteración, se conecten los eventos de búsqueda, alta, actualización y exportación contra `CompraController`.

```
```
