### PR TITLE
feat(compras): implementa listado en tabla

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/view/compras/PanelCompras.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/compras/PanelCompras.java
@@ -6,7 +6,9 @@ import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.sql.Date;
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 
 import javax.swing.GroupLayout;
 import javax.swing.GroupLayout.Alignment;
@@ -23,9 +25,14 @@ import javax.swing.LayoutStyle.ComponentPlacement;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.text.MaskFormatter;
 
+import com.kathsoft.kathpos.app.model.compra.CompraFiltro;
+import com.kathsoft.kathpos.app.model.compra.CompraListado;
 import com.kathsoft.kathpos.app.model.compra.TipoCompraFiltro;
 import com.kathsoft.kathpos.app.model.viewmodel.JComboboxDataViewModel;
 import com.kathsoft.kathpos.tools.AppContext;
+import com.kathsoft.kathpos.tools.ConstantsConllections;
+import com.kathsoft.kathpos.tools.DataTools;
+import com.kathsoft.kathpos.tools.MessageHandler;
 
 public class PanelCompras extends JPanel {
 
@@ -110,6 +117,7 @@ public class PanelCompras extends JPanel {
 		this.tablaCompras.setModel(this.modelTablaCompras);
 		this.scrollPaneTablaCompras.setViewportView(this.tablaCompras);
 		this.setDefaultTableModel();
+		DataTools.removerEditorDeTabla(this.tablaCompras, this.modelTablaCompras);
 
 		this.panelFiltros = new JPanel();
 		this.panelFiltros.setBackground(new Color(0, 153, 255));
@@ -154,12 +162,18 @@ public class PanelCompras extends JPanel {
 		this.btnBuscar.setBackground(new Color(184, 134, 11));
 		this.btnBuscar.setIcon(
 				new ImageIcon(PanelCompras.class.getResource("/com/kathsoft/kathpos/app/assets/buscar_ico.png")));
+		this.btnBuscar.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				llenarTablaCompras();
+			}
+		});
 
 		this.btnLimpiar = new JButton("Limpiar");
 		this.btnLimpiar.setBackground(new Color(176, 196, 222));
 		this.btnLimpiar.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent e) {
 				limpiarFiltros();
+				llenarTablaCompras();
 			}
 		});
 		
@@ -227,6 +241,7 @@ public class PanelCompras extends JPanel {
 		);
 		this.panelFiltros.setLayout(glPanelFiltros);
 		this.panelPrincipalContenedor.setLayout(glPanelPrincipalContenedor);
+		this.llenarTablaCompras();
 	}
 
 	private void setDefaultTableModel() {
@@ -241,6 +256,78 @@ public class PanelCompras extends JPanel {
 		this.modelTablaCompras.addColumn("IVA");
 		this.modelTablaCompras.addColumn("Total");
 		this.modelTablaCompras.addColumn("Activo");
+		DataTools.definirTamanioDeColumnas(ConstantsConllections.tablaComprasColumnsWidth, this.tablaCompras);
+	}
+
+	private void borrarElementosDeLaTablaCompras() {
+		this.modelTablaCompras.getDataVector().removeAllElements();
+		this.tablaCompras.updateUI();
+	}
+
+	public void llenarTablaCompras() {
+		this.borrarElementosDeLaTablaCompras();
+		try {
+			CompraFiltro filtro = this.buildCompraFiltro();
+			AppContext.compraController.listCompras(filtro).forEach(this::addCompraListadoToTable);
+		} catch (ParseException er) {
+			er.printStackTrace(System.err);
+			MessageHandler.displayMessage(MessageHandler.ERROR_MESSAGE, this, "Formato de fecha inválido. Usa dd/MM/yyyy");
+		} catch (Exception er) {
+			er.printStackTrace(System.err);
+			MessageHandler.displayMessage(MessageHandler.ERROR_MESSAGE, this, er.getMessage());
+		}
+	}
+
+	private void addCompraListadoToTable(CompraListado compra) {
+		if (compra == null) {
+			return;
+		}
+
+		this.modelTablaCompras.addRow(new Object[] {
+				compra.getIdCompra(),
+				compra.getIdEmpleado(),
+				compra.getIdProveedor(),
+				compra.getFolioFactura(),
+				compra.getFechaFactura(),
+				compra.getFechaCompra(),
+				compra.getTipoCompraDescripcion(),
+				compra.getSubtotal(),
+				compra.getIva(),
+				compra.getImporteTotal(),
+				compra.isActivo() ? "Activo" : "Inactivo"
+		});
+	}
+
+	private CompraFiltro buildCompraFiltro() throws ParseException {
+		JComboboxDataViewModel proveedorSeleccionado = (JComboboxDataViewModel) this.cmbProveedor.getSelectedItem();
+		TipoCompraFiltro tipoCompraFiltro = this.getTipoCompraFiltroSeleccionado();
+
+		return new CompraFiltro(
+				proveedorSeleccionado == null ? 0 : proveedorSeleccionado.id(),
+				this.parseFechaFiltro(this.formattedTextFieldFechaInicio),
+				this.parseFechaFiltro(this.formattedTextFieldFechaFin),
+				this.txfFolioFactura.getText().trim(),
+				tipoCompraFiltro == null ? null : tipoCompraFiltro.getValor()
+		);
+	}
+
+	private Date parseFechaFiltro(JFormattedTextField fechaField) throws ParseException {
+		String fecha = fechaField.getText() == null ? "" : fechaField.getText().trim();
+		if (this.isFechaVacia(fecha)) {
+			return null;
+		}
+
+		if (fecha.contains("_")) {
+			throw new ParseException("Fecha incompleta", 0);
+		}
+
+		SimpleDateFormat dateFormat = new SimpleDateFormat("dd/MM/yyyy");
+		dateFormat.setLenient(false);
+		return new Date(dateFormat.parse(fecha).getTime());
+	}
+
+	private boolean isFechaVacia(String fecha) {
+		return fecha == null || fecha.trim().isEmpty() || "__/__/____".equals(fecha.trim());
 	}
 
 	private void llenarCmbProveedor() {

--- a/src/main/java/com/kathsoft/kathpos/tools/ConstantsConllections.java
+++ b/src/main/java/com/kathsoft/kathpos/tools/ConstantsConllections.java
@@ -87,6 +87,19 @@ public class ConstantsConllections implements java.io.Serializable{
 			90, // Accion
 	};
 	
+	public static final int[] tablaComprasColumnsWidth = { 50, // id compra
+			120, // empleado
+			120, // proveedor
+			140, // folio factura
+			120, // fecha factura
+			120, // fecha compra
+			110, // tipo compra
+			120, // subtotal
+			120, // iva
+			120, // total
+			100 // activo o inactivo
+	};
+	
 	public static final int[] tablaSucursalesColumnWidth = { 40, // indice
 			150, // nombre
 			300, // descripcion


### PR DESCRIPTION
## Resumen

Esta PR conecta la tabla de `PanelCompras` con el listado de compras mediante `CompraController`.

## Cambios

- Agrega `tablaComprasColumnsWidth` en `ConstantsConllections`.
- Asigna tamaños de columnas en `PanelCompras` con `DataTools.definirTamanioDeColumnas`.
- Remueve el editor de la tabla con `DataTools.removerEditorDeTabla`.
- Conecta `btnBuscar` para ejecutar `llenarTablaCompras()`.
- Construye `CompraFiltro` desde proveedor, folio, fechas y tipo de compra.
- Parsea fechas con formato `dd/MM/yyyy`.
- Carga la tabla al abrir el panel.
- Limpia filtros y recarga el listado desde `btnLimpiar`.

## SP en contexto

Para esta PR se usa:

```sql
CALL listCompras(?,?,?,?,?);
```

El módulo también tiene contemplados estos SP para siguientes iteraciones:

```sql
CALL getCompraById(?);
CALL listArticulosCompraById(?);
CALL insertCompra(?,?,?,?,?,?,?,?);
CALL insertArticuloCompra(?,?,?,?);
CALL sumarExistenciaSucursalCompra(?,?,?);
CALL updateCompra(?,?,?,?,?,?,?,?,?);
CALL updateArticuloCompra(?,?,?);
CALL deleteArticuloCompra(?);
```

## Archivos modificados

```text
src/main/java/com/kathsoft/kathpos/app/view/compras/PanelCompras.java
src/main/java/com/kathsoft/kathpos/tools/ConstantsConllections.java
```

## Fuera de alcance

No incluye formularios de alta/edición, eliminación de compras, exportación a Excel, integración adicional con `Fr_principal` ni creación/modificación de SP.