### PR TITLE
Refactor table structure and shared components for purchases module

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/model/interfaces/IListadoArticulosAcciones.java
+++ b/src/main/java/com/kathsoft/kathpos/app/model/interfaces/IListadoArticulosAcciones.java
@@ -1,0 +1,51 @@
+package com.kathsoft.kathpos.app.model.interfaces;
+
+import com.kathsoft.kathpos.app.model.ArticulosPorVentas;
+
+/**
+ * Define el contrato que deben implementar los formularios que requieren
+ * recibir artículos seleccionados desde {@link Fr_ListaArticulos}.
+ * <p>
+ * Esta interfaz permite reutilizar el formulario auxiliar de consulta de
+ * artículos en distintos módulos del sistema, por ejemplo punto de venta
+ * y compras, sin acoplar {@code Fr_ListaArticulos} a una tabla, modelo o
+ * flujo específico.
+ * </p>
+ * <p>
+ * Cada formulario que invoque {@code Fr_ListaArticulos} decide cómo procesar
+ * el artículo seleccionado: agregarlo a una lista de venta, agregarlo a una
+ * lista de compra, actualizar una tabla temporal, calcular importes o aplicar
+ * cualquier otra regla propia del módulo.
+ * </p>
+ *
+ * @author Pablo Gómez Pérez
+ */
+public interface IListadoArticulosAcciones {
+	
+	/**
+	 * Recibe el artículo seleccionado desde el formulario auxiliar
+	 * {@link Fr_ListaArticulos} y delega al formulario invocador la forma
+	 * concreta de agregarlo o procesarlo.
+	 * <p>
+	 * Este método es llamado por {@code Fr_ListaArticulos} cuando el usuario
+	 * selecciona un artículo de la consulta. El formulario que implementa esta
+	 * interfaz debe encargarse de adaptar la información recibida a su propio
+	 * modelo de tabla o flujo de negocio.
+	 * </p>
+	 * <p>
+	 * Por ejemplo, en punto de venta el artículo puede agregarse a una tabla
+	 * de artículos vendidos; mientras que en compras puede agregarse a una
+	 * tabla de artículos comprados. La diferencia de comportamiento queda
+	 * encapsulada en la implementación de cada formulario.
+	 * </p>
+	 *
+	 * @param articulo arreglo con los datos visuales o tabulares del artículo
+	 *                 seleccionado. Su estructura depende de las columnas que
+	 *                 maneje el formulario auxiliar de consulta.
+	 * @param art objeto auxiliar con la información del artículo seleccionado,
+	 *            usado por el formulario invocador para mapearlo a su propio
+	 *            flujo de operación.
+	 */
+	public void listarArticuloDesdeConsulta(Object[] articulo, ArticulosPorVentas art);
+	
+}

--- a/src/main/java/com/kathsoft/kathpos/app/view/compras/PanelCompras.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/compras/PanelCompras.java
@@ -6,7 +6,9 @@ import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.sql.Date;
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 
 import javax.swing.GroupLayout;
 import javax.swing.GroupLayout.Alignment;
@@ -23,9 +25,14 @@ import javax.swing.LayoutStyle.ComponentPlacement;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.text.MaskFormatter;
 
+import com.kathsoft.kathpos.app.model.compra.CompraFiltro;
+import com.kathsoft.kathpos.app.model.compra.CompraListado;
 import com.kathsoft.kathpos.app.model.compra.TipoCompraFiltro;
 import com.kathsoft.kathpos.app.model.viewmodel.JComboboxDataViewModel;
 import com.kathsoft.kathpos.tools.AppContext;
+import com.kathsoft.kathpos.tools.ConstantsConllections;
+import com.kathsoft.kathpos.tools.DataTools;
+import com.kathsoft.kathpos.tools.MessageHandler;
 
 public class PanelCompras extends JPanel {
 
@@ -110,6 +117,7 @@ public class PanelCompras extends JPanel {
 		this.tablaCompras.setModel(this.modelTablaCompras);
 		this.scrollPaneTablaCompras.setViewportView(this.tablaCompras);
 		this.setDefaultTableModel();
+		DataTools.removerEditorDeTabla(this.tablaCompras, this.modelTablaCompras);
 
 		this.panelFiltros = new JPanel();
 		this.panelFiltros.setBackground(new Color(0, 153, 255));
@@ -154,12 +162,18 @@ public class PanelCompras extends JPanel {
 		this.btnBuscar.setBackground(new Color(184, 134, 11));
 		this.btnBuscar.setIcon(
 				new ImageIcon(PanelCompras.class.getResource("/com/kathsoft/kathpos/app/assets/buscar_ico.png")));
+		this.btnBuscar.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				llenarTablaCompras();
+			}
+		});
 
 		this.btnLimpiar = new JButton("Limpiar");
 		this.btnLimpiar.setBackground(new Color(176, 196, 222));
 		this.btnLimpiar.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent e) {
 				limpiarFiltros();
+				llenarTablaCompras();
 			}
 		});
 		
@@ -227,6 +241,7 @@ public class PanelCompras extends JPanel {
 		);
 		this.panelFiltros.setLayout(glPanelFiltros);
 		this.panelPrincipalContenedor.setLayout(glPanelPrincipalContenedor);
+		this.llenarTablaCompras();
 	}
 
 	private void setDefaultTableModel() {
@@ -241,6 +256,78 @@ public class PanelCompras extends JPanel {
 		this.modelTablaCompras.addColumn("IVA");
 		this.modelTablaCompras.addColumn("Total");
 		this.modelTablaCompras.addColumn("Activo");
+		DataTools.definirTamanioDeColumnas(ConstantsConllections.tablaComprasColumnsWidth, this.tablaCompras);
+	}
+
+	private void borrarElementosDeLaTablaCompras() {
+		this.modelTablaCompras.getDataVector().removeAllElements();
+		this.tablaCompras.updateUI();
+	}
+
+	public void llenarTablaCompras() {
+		this.borrarElementosDeLaTablaCompras();
+		try {
+			CompraFiltro filtro = this.buildCompraFiltro();
+			AppContext.compraController.listCompras(filtro).forEach(this::addCompraListadoToTable);
+		} catch (ParseException er) {
+			er.printStackTrace(System.err);
+			MessageHandler.displayMessage(MessageHandler.ERROR_MESSAGE, this, "Formato de fecha inválido. Usa dd/MM/yyyy");
+		} catch (Exception er) {
+			er.printStackTrace(System.err);
+			MessageHandler.displayMessage(MessageHandler.ERROR_MESSAGE, this, er.getMessage());
+		}
+	}
+
+	private void addCompraListadoToTable(CompraListado compra) {
+		if (compra == null) {
+			return;
+		}
+
+		this.modelTablaCompras.addRow(new Object[] {
+				compra.getIdCompra(),
+				compra.getIdEmpleado(),
+				compra.getIdProveedor(),
+				compra.getFolioFactura(),
+				compra.getFechaFactura(),
+				compra.getFechaCompra(),
+				compra.getTipoCompraDescripcion(),
+				compra.getSubtotal(),
+				compra.getIva(),
+				compra.getImporteTotal(),
+				compra.isActivo() ? "Activo" : "Inactivo"
+		});
+	}
+
+	private CompraFiltro buildCompraFiltro() throws ParseException {
+		JComboboxDataViewModel proveedorSeleccionado = (JComboboxDataViewModel) this.cmbProveedor.getSelectedItem();
+		TipoCompraFiltro tipoCompraFiltro = this.getTipoCompraFiltroSeleccionado();
+
+		return new CompraFiltro(
+				proveedorSeleccionado == null ? 0 : proveedorSeleccionado.id(),
+				this.parseFechaFiltro(this.formattedTextFieldFechaInicio),
+				this.parseFechaFiltro(this.formattedTextFieldFechaFin),
+				this.txfFolioFactura.getText().trim(),
+				tipoCompraFiltro == null ? null : tipoCompraFiltro.getValor()
+		);
+	}
+
+	private Date parseFechaFiltro(JFormattedTextField fechaField) throws ParseException {
+		String fecha = fechaField.getText() == null ? "" : fechaField.getText().trim();
+		if (this.isFechaVacia(fecha)) {
+			return null;
+		}
+
+		if (fecha.contains("_")) {
+			throw new ParseException("Fecha incompleta", 0);
+		}
+
+		SimpleDateFormat dateFormat = new SimpleDateFormat("dd/MM/yyyy");
+		dateFormat.setLenient(false);
+		return new Date(dateFormat.parse(fecha).getTime());
+	}
+
+	private boolean isFechaVacia(String fecha) {
+		return fecha == null || fecha.trim().isEmpty() || "__/__/____".equals(fecha.trim());
 	}
 
 	private void llenarCmbProveedor() {

--- a/src/main/java/com/kathsoft/kathpos/app/view/shared/Fr_ListaArticulos.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/shared/Fr_ListaArticulos.java
@@ -1,4 +1,4 @@
-package com.kathsoft.kathpos.app.view.articulo;
+package com.kathsoft.kathpos.app.view.shared;
 
 
 import java.awt.BorderLayout;
@@ -28,6 +28,7 @@ import com.kathsoft.kathpos.app.controller.ArticuloController;
 import com.kathsoft.kathpos.app.model.ArticulosPorVentas;
 import com.kathsoft.kathpos.app.model.articulo.Articulo;
 import com.kathsoft.kathpos.app.view.ventas.Fr_PuntoDeVentas;
+import com.kathsoft.kathpos.tools.ConstantsConllections;
 
 public class Fr_ListaArticulos extends JFrame {
 
@@ -50,18 +51,7 @@ public class Fr_ListaArticulos extends JFrame {
 	private Component horizontalStrut_1;
 	private JButton btnBusquedaArticulo;
 	private JPanel panelCentralTabla;
-	private JScrollPane scrollPaneTablaArticulo;
-	private int[] tablaArticulosColumnsWidth = { 40, /* id */
-			150, /* codigo */
-			200, /* proveedor */
-			180, /* categoría */
-			100, /* codigo sat */
-			300, /* Nombre */
-			450, /* descripcion */
-			100, /* Existencia */
-			100, /* Precio g */
-			100 /* Precio m */
-	};
+	private JScrollPane scrollPaneTablaArticulo;	
 	private JPanel panelInferiorBotones;
 	private JButton btnCancelar;
 	private Component horizontalStrut_2;
@@ -189,9 +179,9 @@ public class Fr_ListaArticulos extends JFrame {
 		 */
 		TableColumnModel articulosColumnModel = tablaArticulos.getColumnModel();
 
-		for (int i = 0; i < tablaArticulosColumnsWidth.length; i++) {
-			articulosColumnModel.getColumn(i).setPreferredWidth(tablaArticulosColumnsWidth[i]);
-			articulosColumnModel.getColumn(i).setMinWidth(tablaArticulosColumnsWidth[i]);
+		for (int i = 0; i < ConstantsConllections.tablaArticulosListadoColumnsWidth.length; i++) {
+			articulosColumnModel.getColumn(i).setPreferredWidth(ConstantsConllections.tablaArticulosListadoColumnsWidth[i]);
+			articulosColumnModel.getColumn(i).setMinWidth(ConstantsConllections.tablaArticulosListadoColumnsWidth[i]);
 		}
 
 		this.llenarTablaArticulos(this.nombreArticulo);

--- a/src/main/java/com/kathsoft/kathpos/app/view/shared/Fr_ListaArticulos.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/shared/Fr_ListaArticulos.java
@@ -27,6 +27,7 @@ import javax.swing.table.TableColumnModel;
 import com.kathsoft.kathpos.app.controller.ArticuloController;
 import com.kathsoft.kathpos.app.model.ArticulosPorVentas;
 import com.kathsoft.kathpos.app.model.articulo.Articulo;
+import com.kathsoft.kathpos.app.model.interfaces.IListadoArticulosAcciones;
 import com.kathsoft.kathpos.app.view.ventas.Fr_PuntoDeVentas;
 import com.kathsoft.kathpos.tools.ConstantsConllections;
 
@@ -41,7 +42,17 @@ public class Fr_ListaArticulos extends JFrame {
 	private ArticuloController articuloController = new ArticuloController();
 	private String nombreArticulo;
 	private int idSucursal;
-	private Fr_PuntoDeVentas puntoVenta;
+	
+	/**
+	 * Referencia al formulario invocador que recibirá el artículo seleccionado.
+	 * <p>
+	 * El objeto debe implementar {@link IListadoArticulosAcciones}, lo que permite
+	 * que {@code Fr_ListaArticulos} notifique la selección sin conocer el tipo
+	 * concreto del formulario ni la forma en que será actualizado.
+	 * </p>
+	 */
+	private IListadoArticulosAcciones frame;
+	
 	private JPanel contentPane;
 	private JTextField txfNombreArticulo;
 	private JTable tablaArticulos;
@@ -67,13 +78,31 @@ public class Fr_ListaArticulos extends JFrame {
 	 */
 
 	/**
-	 * Create the frame.
+	 * Crea el formulario auxiliar para consultar y seleccionar artículos.
+	 * <p>
+	 * Este formulario se utiliza como una ventana de apoyo para buscar artículos
+	 * por nombre y permitir que el usuario seleccione uno de los resultados.
+	 * Al seleccionar un artículo, el resultado se devuelve al formulario invocador
+	 * mediante la interfaz {@link IListadoArticulosAcciones}.
+	 * </p>
+	 * <p>
+	 * El uso de la interfaz permite que este mismo formulario auxiliar sea
+	 * reutilizado por distintos módulos, como punto de venta y compras, sin crear
+	 * formularios duplicados ni constructores específicos para cada caso.
+	 * </p>
+	 *
+	 * @param nombreArticulo texto inicial de búsqueda para filtrar artículos.
+	 * @param idSucursal identificador de la sucursal sobre la cual se consulta
+	 *                   la disponibilidad o información del artículo.
+	 * @param frame formulario invocador que implementa
+	 *              {@link IListadoArticulosAcciones} y recibirá el artículo
+	 *              seleccionado.
 	 */
-	public Fr_ListaArticulos(String nombreArticulo, int idSucursal, Fr_PuntoDeVentas frame) {
+	public Fr_ListaArticulos(String nombreArticulo, int idSucursal, IListadoArticulosAcciones frame) {
 
 		this.nombreArticulo = nombreArticulo;
 		this.idSucursal = idSucursal;
-		this.puntoVenta = frame;
+		this.frame = frame;
 
 		setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 		setBounds(100, 100, 730, 450);
@@ -235,7 +264,7 @@ public class Fr_ListaArticulos extends JFrame {
 			vendidos.setCantidad(cantidad);
 			vendidos.setSubtotal(subtotal);
 			
-			this.puntoVenta.listarArticuloDesdeConsulta(fila, vendidos);
+			this.frame.listarArticuloDesdeConsulta(fila, vendidos);
 
 		} catch (Exception er) {
 			er.printStackTrace();

--- a/src/main/java/com/kathsoft/kathpos/app/view/ventas/Fr_PuntoDeVentas.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/ventas/Fr_PuntoDeVentas.java
@@ -50,11 +50,12 @@ import com.kathsoft.kathpos.app.model.Ventas;
 import com.kathsoft.kathpos.app.model.articulo.Articulo;
 import com.kathsoft.kathpos.app.model.cliente.Clientes;
 import com.kathsoft.kathpos.app.model.empleado.Empleado;
+import com.kathsoft.kathpos.app.model.interfaces.IListadoArticulosAcciones;
 import com.kathsoft.kathpos.app.model.viewmodel.JComboboxDataViewModel;
 import com.kathsoft.kathpos.app.view.formas_pago.Fr_FormasDePago;
 import com.kathsoft.kathpos.app.view.shared.Fr_ListaArticulos;
 
-public class Fr_PuntoDeVentas extends JFrame {
+public class Fr_PuntoDeVentas extends JFrame implements IListadoArticulosAcciones{
 
 	/**
 	 * 
@@ -832,6 +833,7 @@ public class Fr_PuntoDeVentas extends JFrame {
 	 * 
 	 * @param articulo
 	 */
+	@Override
 	public void listarArticuloDesdeConsulta(Object[] articulo, ArticulosPorVentas art) {		
 		modelTablaArticulo.addRow(articulo);
 		if(this.articulosVendidos == null) {

--- a/src/main/java/com/kathsoft/kathpos/app/view/ventas/Fr_PuntoDeVentas.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/ventas/Fr_PuntoDeVentas.java
@@ -51,8 +51,8 @@ import com.kathsoft.kathpos.app.model.articulo.Articulo;
 import com.kathsoft.kathpos.app.model.cliente.Clientes;
 import com.kathsoft.kathpos.app.model.empleado.Empleado;
 import com.kathsoft.kathpos.app.model.viewmodel.JComboboxDataViewModel;
-import com.kathsoft.kathpos.app.view.articulo.Fr_ListaArticulos;
 import com.kathsoft.kathpos.app.view.formas_pago.Fr_FormasDePago;
+import com.kathsoft.kathpos.app.view.shared.Fr_ListaArticulos;
 
 public class Fr_PuntoDeVentas extends JFrame {
 

--- a/src/main/java/com/kathsoft/kathpos/tools/ConstantsConllections.java
+++ b/src/main/java/com/kathsoft/kathpos/tools/ConstantsConllections.java
@@ -76,6 +76,21 @@ public class ConstantsConllections implements java.io.Serializable{
 	// Array que define el ancho de cada columna de la tabla de categoría
 	public static final int[] tablaCategoriaColumnsWidth = { 40, 180, 400 };
 	
+	/**
+	 * define el ancho de columnas de la tabla en el formulario de selección de articulos
+	 */
+	public static int[] tablaArticulosListadoColumnsWidth = { 40, /* id */
+			150, /* codigo */
+			200, /* proveedor */
+			180, /* categoría */
+			100, /* codigo sat */
+			300, /* Nombre */
+			450, /* descripcion */
+			100, /* Existencia */
+			100, /* Precio g */
+			100 /* Precio m */
+	};
+	
 	public static final int[] tablaVentasColumnsWidth = { 50, // i venta
 			120, // fecha venta
 			100, // tipo venta

--- a/src/main/java/com/kathsoft/kathpos/tools/ConstantsConllections.java
+++ b/src/main/java/com/kathsoft/kathpos/tools/ConstantsConllections.java
@@ -87,6 +87,19 @@ public class ConstantsConllections implements java.io.Serializable{
 			90, // Accion
 	};
 	
+	public static final int[] tablaComprasColumnsWidth = { 50, // id compra
+			120, // empleado
+			120, // proveedor
+			140, // folio factura
+			120, // fecha factura
+			120, // fecha compra
+			110, // tipo compra
+			120, // subtotal
+			120, // iva
+			120, // total
+			100 // activo o inactivo
+	};
+	
 	public static final int[] tablaSucursalesColumnWidth = { 40, // indice
 			150, // nombre
 			300, // descripcion


### PR DESCRIPTION
## Resumen

Esta PR integra `dev` hacia `main` con avances funcionales y estructurales del módulo de compras.

El alcance principal incluye el listado de compras en tabla, la configuración visual de columnas, la conexión inicial de filtros contra `CompraController` y un refactor en el flujo de consulta de artículos para permitir que el formulario auxiliar de artículos pueda reutilizarse tanto en ventas como en compras.

---

## Rama origen y destino

```text
Origen: feat/compras-listado-tabla
Destino: main
````

---

## Commits incluidos

```text
26756ff feat(compras): define anchos de tabla compras
b1ff2a2 feat(compras): implementa listado en tabla
697394d refact(Fr_ListadoCompras): cambio estructural
9c8a0d2 refact: Cambio en flujo de consulta de artículos
```

---

## Cambios principales

### 1. Tamaños de columnas para tabla de compras

Se agrega el arreglo de configuración de columnas para la tabla del módulo de compras dentro de `ConstantsConllections`.

Esto permite centralizar los anchos de columnas y mantener el mismo patrón usado por otros módulos del sistema.

```java
ConstantsConllections.tablaComprasColumnsWidth
```

---

### 2. Configuración de tabla en `PanelCompras`

Se actualiza `PanelCompras` para aplicar la configuración visual de la tabla.

Cambios incluidos:


- asignación de tamaños de columnas;
- uso de DataTools.definirTamanioDeColumnas(...);
- remoción del editor de tabla;
- uso de DataTools.removerEditorDeTabla(...).


Con esto, la tabla de compras queda en modo solo lectura y con dimensiones consistentes para sus columnas.

---

### 3. Implementación del listado de compras

Se conecta el listado de compras desde `PanelCompras` utilizando `CompraController`.

La tabla queda preparada para mostrar compras con los datos principales:

```text
Id
Empleado
Proveedor
Folio Factura
Fecha Factura
Fecha Compra
Tipo Compra
Subtotal
IVA
Total
Activo
```

El flujo de listado utiliza el filtro visual construido desde el panel.

---

### 4. Filtros para listado de compras

Se implementa la construcción de filtros desde los controles visuales de `PanelCompras`.

Criterios considerados:

```text
Proveedor
Folio factura
Fecha factura inicio
Fecha factura fin
Tipo compra
```

El filtro se construye mediante el modelo:

```java
CompraFiltro
```

y se envía al controlador para ejecutar el listado.

---

### 5. Consulta mediante procedimiento almacenado

El listado queda conectado al procedimiento almacenado esperado:

```sql
CALL listCompras(?,?,?,?,?);
```

Este procedimiento recibe los filtros de búsqueda y devuelve la información necesaria para llenar la tabla de compras.

---

### 6. Carga inicial de tabla

`PanelCompras` queda preparado para cargar el listado al abrir el panel, usando los filtros iniciales por defecto.

Esto permite que el módulo muestre información desde el primer acceso, sin depender manualmente de una búsqueda inicial.

---

### 7. Refactor estructural en `Fr_ListadoCompras`

Se realiza un cambio estructural en `Fr_ListadoCompras` para preparar el flujo de compras con una separación más clara entre la vista, la selección de artículos y la carga de información al listado correspondiente.

Este cambio deja el formulario mejor alineado con el flujo futuro de alta o edición de compras.

---

### 8. Refactor del flujo de consulta de artículos

Se modifica el flujo de consulta de artículos para reutilizar el formulario auxiliar de búsqueda sin acoplarlo exclusivamente a ventas o compras.

Se introduce el uso de una interfaz de callback:

```java
public interface IListadoArticulosAcciones {

    public void listarArticuloDesdeConsulta(Object[] articulo, ArticulosPorVentas art);

}
```

El formulario auxiliar de artículos recibe ahora una referencia del formulario invocador mediante:

```java
public Fr_ListaArticulos(String nombreArticulo, int idSucursal, IListadoArticulosAcciones frame)
```

Esto permite que `Fr_ListaArticulos` siga siendo un formulario genérico de consulta y selección, mientras que cada módulo decide cómo procesar el artículo seleccionado.

---

### 9. Reutilización de `Fr_ListaArticulos`

Con el nuevo flujo, `Fr_ListaArticulos` puede ser reutilizado por distintos formularios:

- formulario de punto de venta;
- formulario/listado de compras;
- futuros formularios que requieran seleccionar artículos.


La diferencia de comportamiento queda delegada a la implementación de `IListadoArticulosAcciones`.

Así se evita crear otro constructor específico o duplicar un formulario de consulta de artículos para compras.

---

## Archivos principales impactados

```bash
src/main/java/com/kathsoft/kathpos/tools/ConstantsConllections.java
src/main/java/com/kathsoft/kathpos/app/view/compras/PanelCompras.java
src/main/java/com/kathsoft/kathpos/app/view/compras/Fr_ListadoCompras.java
src/main/java/com/kathsoft/kathpos/app/view/articulo/Fr_ListaArticulos.java
src/main/java/com/kathsoft/kathpos/app/view/articulo/IListadoArticulosAcciones.java
```

---

## Procedimientos almacenados en contexto

Para el listado de compras se utiliza:

```sql
CALL listCompras(?,?,?,?,?);
```

El módulo de compras mantiene contemplados para siguientes iteraciones:

```sql
CALL getCompraById(?);
CALL listArticulosCompraById(?);
CALL insertCompra(?,?,?,?,?,?,?,?);
CALL insertArticuloCompra(?,?,?,?);
CALL sumarExistenciaSucursalCompra(?,?,?);
CALL updateCompra(?,?,?,?,?,?,?,?,?);
CALL updateArticuloCompra(?,?,?);
CALL deleteArticuloCompra(?);
```

---

## Alcance de esta PR

Esta PR incluye:

- configuración de anchos de columnas para tabla de compras;
- tabla de compras en modo solo lectura;
- conexión inicial del listado de compras;
- construcción de filtros desde PanelCompras;
- carga inicial de compras en tabla;
- refactor estructural en Fr_ListadoCompras;
- refactor del flujo de consulta de artículos;
- interfaz para desacoplar Fr_ListaArticulos del formulario invocador.

---

## Fuera de alcance

Esta PR no incluye:

- eliminación completa de compras;
- alta completa de compra;
- edición completa de compra;
- lógica final de guardado de artículos comprados;
- exportación real a Excel desde compras;
- integración adicional con Fr_principal;
- creación o modificación de procedimientos almacenados;
- validaciones finales del formulario de compra.


---

## Nota técnica

El cambio más importante de arquitectura en esta PR es la separación del formulario auxiliar `Fr_ListaArticulos` respecto al módulo que lo consume.

Antes, el flujo de selección de artículos estaba más orientado al punto de venta. Con la interfaz `IListadoArticulosAcciones`, el formulario auxiliar puede notificar el artículo seleccionado sin conocer si será agregado a una venta, a una compra o a otro flujo posterior.

Esto permite reutilizar componentes Swing existentes y evita duplicar formularios de consulta para cada módulo.

