### PR TITLE
refactor(compras): usa sucursal explícita en flujo de compras

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/controller/CompraController.java
+++ b/src/main/java/com/kathsoft/kathpos/app/controller/CompraController.java
@@ -24,11 +24,11 @@ public class CompraController implements java.io.Serializable {
 	private static final long serialVersionUID = -4974480297011718553L;
 	private static Connection cn = null;
 
-	public List<CompraListado> listCompras() {
-		return this.listCompras(new CompraFiltro());
+	public List<CompraListado> listCompras(int idSucursal) {
+		return this.listCompras(idSucursal, new CompraFiltro());
 	}
 
-	public List<CompraListado> listCompras(CompraFiltro filtro) {
+	public List<CompraListado> listCompras(int idSucursal, CompraFiltro filtro) {
 		CallableStatement stm = null;
 		ResultSet rset = null;
 		List<CompraListado> compras = new ArrayList<>();
@@ -36,12 +36,13 @@ public class CompraController implements java.io.Serializable {
 		try {
 			CompraFiltro filtroCompras = filtro == null ? new CompraFiltro() : filtro;
 			cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
-			stm = cn.prepareCall("CALL listCompras(?,?,?,?,?)");
-			setNullableInt(stm, 1, filtroCompras.getIdProveedor());
-			stm.setDate(2, filtroCompras.getFechaFacturaInicio());
-			stm.setDate(3, filtroCompras.getFechaFacturaFin());
-			stm.setString(4, filtroCompras.getFolioFactura());
-			setNullableBoolean(stm, 5, filtroCompras.getTipoCompra());
+			stm = cn.prepareCall("CALL listCompras(?,?,?,?,?,?)");
+			stm.setLong(1, idSucursal);
+			setNullableInt(stm, 2, filtroCompras.getIdProveedor());
+			stm.setDate(3, filtroCompras.getFechaFacturaInicio());
+			stm.setDate(4, filtroCompras.getFechaFacturaFin());
+			stm.setString(5, filtroCompras.getFolioFactura());
+			setNullableBoolean(stm, 6, filtroCompras.getTipoCompra());
 			rset = stm.executeQuery();
 
 			while (rset.next()) {
@@ -155,9 +156,9 @@ public class CompraController implements java.io.Serializable {
 		return new CompraConDetalle(compra, articulosPorCompra);
 	}
 
-	public SpResponseModel insertCompra(Compra compra) {
+	public SpResponseModel insertCompra(int idSucursal, Compra compra) {
 		try (Connection connection = Conexion.establecerConexionLocal(Conexion.DATA_BASE)) {
-			return this.insertCompra(connection, compra);
+			return this.insertCompra(connection, idSucursal, compra);
 		} catch (SQLException er) {
 			er.printStackTrace();
 			return new SpResponseModel(500, er.getMessage());
@@ -167,7 +168,7 @@ public class CompraController implements java.io.Serializable {
 		}
 	}
 
-	public SpResponseModel insertCompra(CompraConDetalle compraConDetalle) {
+	public SpResponseModel insertCompra(int idSucursal, CompraConDetalle compraConDetalle) {
 		if (compraConDetalle == null || compraConDetalle.getCompra() == null) {
 			return new SpResponseModel(500, "La compra es obligatoria");
 		}
@@ -180,7 +181,7 @@ public class CompraController implements java.io.Serializable {
 			connection.setAutoCommit(false);
 
 			try {
-				SpResponseModel respuestaCompra = this.insertCompra(connection, compraConDetalle.getCompra());
+				SpResponseModel respuestaCompra = this.insertCompra(connection, idSucursal, compraConDetalle.getCompra());
 				if (!isSuccess(respuestaCompra)) {
 					connection.rollback();
 					return respuestaCompra;
@@ -250,9 +251,9 @@ public class CompraController implements java.io.Serializable {
 		}
 	}
 
-	public SpResponseModel updateCompra(Compra compra) {
+	public SpResponseModel updateCompra(int idSucursal, Compra compra) {
 		try (Connection connection = Conexion.establecerConexionLocal(Conexion.DATA_BASE)) {
-			return this.updateCompra(connection, compra);
+			return this.updateCompra(connection, idSucursal, compra);
 		} catch (SQLException er) {
 			er.printStackTrace();
 			return new SpResponseModel(500, er.getMessage());
@@ -274,7 +275,7 @@ public class CompraController implements java.io.Serializable {
 		}
 	}
 
-	public SpResponseModel updateCompra(CompraConDetalle compraConDetalle) {
+	public SpResponseModel updateCompra(int idSucursal, CompraConDetalle compraConDetalle) {
 		if (compraConDetalle == null || compraConDetalle.getCompra() == null) {
 			return new SpResponseModel(500, "La compra es obligatoria");
 		}
@@ -287,7 +288,7 @@ public class CompraController implements java.io.Serializable {
 			connection.setAutoCommit(false);
 
 			try {
-				SpResponseModel respuestaCompra = this.updateCompra(connection, compraConDetalle.getCompra());
+				SpResponseModel respuestaCompra = this.updateCompra(connection, idSucursal, compraConDetalle.getCompra());
 				if (!isSuccess(respuestaCompra)) {
 					connection.rollback();
 					return respuestaCompra;
@@ -352,20 +353,21 @@ public class CompraController implements java.io.Serializable {
 		}
 	}
 
-	private SpResponseModel insertCompra(Connection connection, Compra compra) throws SQLException {
+	private SpResponseModel insertCompra(Connection connection, int idSucursal, Compra compra) throws SQLException {
 		if (compra == null) {
 			return new SpResponseModel(500, "La compra es obligatoria");
 		}
 
-		try (CallableStatement stm = connection.prepareCall("CALL insertCompra(?,?,?,?,?,?,?,?)")) {
+		try (CallableStatement stm = connection.prepareCall("CALL insertCompra(?,?,?,?,?,?,?,?,?)")) {
 			stm.setInt(1, compra.getIdEmpleado());
 			stm.setInt(2, compra.getIdProveedor());
-			stm.setString(3, compra.getFolioFactura());
-			stm.setDate(4, compra.getFechaFactura());
-			stm.setDate(5, compra.getFechaCompra());
-			stm.setBoolean(6, compra.isTipoCompra());
-			stm.setDouble(7, compra.getSubtotal());
-			stm.setDouble(8, compra.getIva());
+			stm.setLong(3, idSucursal);
+			stm.setString(4, compra.getFolioFactura());
+			stm.setDate(5, compra.getFechaFactura());
+			stm.setDate(6, compra.getFechaCompra());
+			stm.setBoolean(7, compra.isTipoCompra());
+			stm.setDouble(8, compra.getSubtotal());
+			stm.setDouble(9, compra.getIva());
 
 			try (ResultSet rset = stm.executeQuery()) {
 				return buildSpResponse(rset);
@@ -404,21 +406,22 @@ public class CompraController implements java.io.Serializable {
 		}
 	}
 
-	private SpResponseModel updateCompra(Connection connection, Compra compra) throws SQLException {
+	private SpResponseModel updateCompra(Connection connection, int idSucursal, Compra compra) throws SQLException {
 		if (compra == null) {
 			return new SpResponseModel(500, "La compra es obligatoria");
 		}
 
-		try (CallableStatement stm = connection.prepareCall("CALL updateCompra(?,?,?,?,?,?,?,?,?)")) {
+		try (CallableStatement stm = connection.prepareCall("CALL updateCompra(?,?,?,?,?,?,?,?,?,?)")) {
 			stm.setInt(1, compra.getIdCompra());
 			stm.setInt(2, compra.getIdEmpleado());
 			stm.setInt(3, compra.getIdProveedor());
-			stm.setString(4, compra.getFolioFactura());
-			stm.setDate(5, compra.getFechaFactura());
-			stm.setDate(6, compra.getFechaCompra());
-			stm.setBoolean(7, compra.isTipoCompra());
-			stm.setDouble(8, compra.getSubtotal());
-			stm.setDouble(9, compra.getIva());
+			stm.setLong(4, idSucursal);
+			stm.setString(5, compra.getFolioFactura());
+			stm.setDate(6, compra.getFechaFactura());
+			stm.setDate(7, compra.getFechaCompra());
+			stm.setBoolean(8, compra.isTipoCompra());
+			stm.setDouble(9, compra.getSubtotal());
+			stm.setDouble(10, compra.getIva());
 
 			try (ResultSet rset = stm.executeQuery()) {
 				return buildSpResponse(rset);
@@ -473,7 +476,7 @@ public class CompraController implements java.io.Serializable {
 	}
 
 	private boolean isSuccess(SpResponseModel response) {
-		return response != null && response.id() == 200;
+		return response != null && response.id() > 0 && response.id() != 500;
 	}
 
 	private void setNullableInt(CallableStatement stm, int index, int value) throws SQLException {

--- a/src/main/java/com/kathsoft/kathpos/app/view/compras/PanelCompras.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/compras/PanelCompras.java
@@ -65,6 +65,16 @@ public class PanelCompras extends JPanel {
 	private JFormattedTextField formattedTextFieldFechaFin;
 	private int idSucursal;
 
+	/**
+	 * Constructor conservado únicamente para compatibilidad con WindowBuilder y
+	 * referencias existentes. Para listar compras debe utilizarse
+	 * {@link #PanelCompras(int)}.
+	 */
+	@Deprecated
+	public PanelCompras() {
+		this(0);
+	}
+
 	public PanelCompras(int idSucursal) {
 		this.idSucursal = idSucursal;
 		this.setLayout(new BorderLayout(0, 0));
@@ -243,7 +253,10 @@ public class PanelCompras extends JPanel {
 		);
 		this.panelFiltros.setLayout(glPanelFiltros);
 		this.panelPrincipalContenedor.setLayout(glPanelPrincipalContenedor);
-		this.llenarTablaCompras();
+
+		if (this.idSucursal > 0) {
+			this.llenarTablaCompras();
+		}
 	}
 
 	private void setDefaultTableModel() {
@@ -267,6 +280,10 @@ public class PanelCompras extends JPanel {
 	}
 
 	public void llenarTablaCompras() {
+		if (this.idSucursal <= 0) {
+			return;
+		}
+
 		this.borrarElementosDeLaTablaCompras();
 		try {
 			CompraFiltro filtro = this.buildCompraFiltro();

--- a/src/main/java/com/kathsoft/kathpos/app/view/compras/PanelCompras.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/compras/PanelCompras.java
@@ -63,8 +63,10 @@ public class PanelCompras extends JPanel {
 	private FlowLayout flowLayoutPanelBotones;
 	private JFormattedTextField formattedTextFieldFechaInicio;
 	private JFormattedTextField formattedTextFieldFechaFin;
+	private int idSucursal;
 
-	public PanelCompras() {
+	public PanelCompras(int idSucursal) {
+		this.idSucursal = idSucursal;
 		this.setLayout(new BorderLayout(0, 0));
 		this.setBackground(new Color(255, 215, 0));
 
@@ -268,7 +270,7 @@ public class PanelCompras extends JPanel {
 		this.borrarElementosDeLaTablaCompras();
 		try {
 			CompraFiltro filtro = this.buildCompraFiltro();
-			AppContext.compraController.listCompras(filtro).forEach(this::addCompraListadoToTable);
+			AppContext.compraController.listCompras(this.idSucursal, filtro).forEach(this::addCompraListadoToTable);
 		} catch (ParseException er) {
 			er.printStackTrace(System.err);
 			MessageHandler.displayMessage(MessageHandler.ERROR_MESSAGE, this, "Formato de fecha inválido. Usa dd/MM/yyyy");


### PR DESCRIPTION
## Resumen

Esta PR adapta el flujo Java del módulo de compras al nuevo modelo donde `compras.id_sucursal` representa directamente la sucursal en la que se realiza la operación.

## Cambios principales

### `CompraController`

- `listCompras` ahora recibe `idSucursal` explícitamente.
- `listCompras` llama `CALL listCompras(?,?,?,?,?,?)` enviando primero la sucursal actual.
- `insertCompra` recibe `idSucursal` y llama `CALL insertCompra(?,?,?,?,?,?,?,?,?)`.
- `updateCompra` recibe `idSucursal` y llama `CALL updateCompra(?,?,?,?,?,?,?,?,?,?)`.
- Los flujos transaccionales de `CompraConDetalle` propagan la sucursal a la cabecera de compra.
- `sumarExistenciaSucursalCompra`, `insertArticuloCompra` y `updateArticuloCompra` conservan sus firmas porque la sucursal se obtiene internamente desde la compra.
- Se ajusta la validación interna de respuesta para aceptar IDs positivos retornados por los SP de inserción/actualización y seguir rechazando el código `500` de error.

### `PanelCompras`

- Se agrega constructor `PanelCompras(int idSucursal)`.
- El panel conserva `idSucursal` como contexto de la sesión.
- `llenarTablaCompras()` llama ahora `AppContext.compraController.listCompras(idSucursal, filtro)`.
- Se mantiene temporalmente el constructor vacío, marcado como `@Deprecated`, para no romper WindowBuilder ni la referencia actual desde `Fr_principal`; este constructor no ejecuta el listado al no contar con sucursal.

## Nuevas firmas relevantes

```java
listCompras(int idSucursal)
listCompras(int idSucursal, CompraFiltro filtro)
insertCompra(int idSucursal, Compra compra)
insertCompra(int idSucursal, CompraConDetalle compraConDetalle)
updateCompra(int idSucursal, Compra compra)
updateCompra(int idSucursal, CompraConDetalle compraConDetalle)
```

## Procedimientos esperados

```sql
CALL listCompras(?,?,?,?,?,?);
CALL insertCompra(?,?,?,?,?,?,?,?,?);
CALL updateCompra(?,?,?,?,?,?,?,?,?,?);
CALL insertArticuloCompra(?,?,?,?);
CALL sumarExistenciaSucursalCompra(?,?,?);
CALL updateArticuloCompra(?,?,?);
```

## Archivos modificados

```text
src/main/java/com/kathsoft/kathpos/app/controller/CompraController.java
src/main/java/com/kathsoft/kathpos/app/view/compras/PanelCompras.java
```

## Fuera de alcance

- No se modifica `Fr_principal`.
- No se modifican modelos de compra.
- No se modifican procedimientos almacenados desde el repositorio.
- No se cambia todavía `getCompraById`, `listArticulosCompraById` ni `deleteArticuloCompra` para validar sucursal.

## Nota de integración

La instancia definitiva del panel deberá construirse desde `Fr_principal` con el ID de la sucursal de sesión, por ejemplo:

```java
new PanelCompras(sucursal.getIdSucursal())
```

El constructor vacío se conserva únicamente como compatibilidad temporal.