### PR TITLE
feat(compras): integra búsqueda y selección inicial de artículos

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/controller/ArticuloController.java
+++ b/src/main/java/com/kathsoft/kathpos/app/controller/ArticuloController.java
@@ -14,16 +14,45 @@ import javax.swing.JOptionPane;
 import javax.swing.table.DefaultTableModel;
 
 import com.kathsoft.kathpos.app.model.articulo.Articulo;
+import com.kathsoft.kathpos.app.model.articulo.ArticuloByCodigo;
 import com.kathsoft.kathpos.app.model.articulo.PrecioTipoCliente;
 import com.kathsoft.kathpos.tools.Conexion;
 
 public class ArticuloController implements java.io.Serializable {
 
 	private static final long serialVersionUID = 8759492279100460054L;
+	private static final int ID_TIPO_CLIENTE_GENERAL = 1;
 	private static Connection cn = null;
 
 	public Vector<Object[]> verArticulosEnTabla(int idSucursal, int idTipoCliente) {
-		return this.verArticulosEnTabla(idSucursal, "TODOS", "NOMBRE", "", idTipoCliente);
+		return this.verArticulosEnTabla(idSucursal, "", idTipoCliente);
+	}
+
+	/**
+	 * Retorna una vista reducida del listado de artículos para formularios de
+	 * selección.
+	 *
+	 * @param idSucursal identificador de la sucursal donde se realiza la consulta
+	 * @param nombreArticulo texto utilizado para filtrar por nombre
+	 * @param idTipoCliente identificador del tipo de cliente para determinar precio
+	 * @return filas con id, código, nombre, costo, precio y existencia
+	 */
+	public Vector<Object[]> verArticulosEnTabla(int idSucursal, String nombreArticulo, int idTipoCliente) {
+		var articulos = new Vector<Object[]>();
+		String textoBusqueda = nombreArticulo == null ? "" : nombreArticulo.trim();
+
+		this.verArticulosEnTabla(idSucursal, "NOMBRE", "NOMBRE", textoBusqueda, idTipoCliente).forEach(articulo -> {
+			articulos.add(new Object[] {
+					articulo[0], // id
+					articulo[3], // código
+					articulo[4], // nombre
+					articulo[6], // costo
+					articulo[7], // precio
+					articulo[8] // existencia
+			});
+		});
+
+		return articulos;
 	}
 
 	public Vector<Object[]> verArticulosEnTabla(int idSucursal, String tipoBusqueda, String ordenarPor,
@@ -290,27 +319,36 @@ public class ArticuloController implements java.io.Serializable {
 	    throw new SQLException("El procedimiento para " + operacion + " no devolvió respuesta");
 	}
 
-	public Articulo consultarArticuloPorCodigo(String codigo, int idSucursal) throws SQLException, Exception {
+	public ArticuloByCodigo consultarArticuloPorCodigo(String codigo, int idSucursal) throws SQLException, Exception {
+		return this.consultarArticuloPorCodigo(codigo, idSucursal, ID_TIPO_CLIENTE_GENERAL);
+	}
 
-		Articulo art = new Articulo();
-		CallableStatement stm = null;
-		ResultSet rset = null;
+	public ArticuloByCodigo consultarArticuloPorCodigo(String codigo, int idSucursal, int idTipoCliente)
+			throws SQLException, Exception {
 
-		try {
-			cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
-			stm = cn.prepareCall("CALL buscar_articulo_por_codigo(?,?);");
+		ArticuloByCodigo art = new ArticuloByCodigo();
+
+		try (Connection cn = Conexion.establecerConexionLocal(Conexion.DATA_BASE);
+				CallableStatement stm = cn.prepareCall("CALL getArticuloByCodigo(?,?,?);")) {
+
 			stm.setString(1, codigo);
 			stm.setInt(2, idSucursal);
-			rset = stm.executeQuery();
+			stm.setInt(3, idTipoCliente);
 
-			if (rset.next()) {
-				art.setIdArticulo(rset.getInt(1));
-				art.setCodigoArticulo(rset.getString(2));
-				art.setNombre(rset.getString(5));
-				art.setCodigoSat(rset.getString(6));
-				art.setDescripcion(rset.getString(7));
-				art.setExento(rset.getInt(9) == 1);
-				art.setCostoUnitario(rset.getDouble(10));
+			try (ResultSet rset = stm.executeQuery()) {
+				if (rset.next()) {
+					art.setIdArticulo(rset.getInt("id_articulo"));
+					art.setIdProveedor(rset.getInt("id_proveedor"));
+					art.setIdCategoria(rset.getInt("id_categoria"));
+					art.setCodigoArticulo(rset.getString("codigo_articulo"));
+					art.setCodigoSat(rset.getString("codigo_sat"));
+					art.setNombre(rset.getString("nombre"));
+					art.setDescripcion(rset.getString("descripcion"));
+					art.setExento(rset.getBoolean("exento"));
+					art.setCostoUnitario(rset.getDouble("costo_unitario"));
+					art.setActivo(rset.getBoolean("activo"));
+					art.setExistencia(rset.getInt("existencia"));
+				}
 			}
 
 			return art;
@@ -324,14 +362,6 @@ public class ArticuloController implements java.io.Serializable {
 			JOptionPane.showMessageDialog(null, "Ha ocurrido un error: [Generic] -> " + er.getMessage(), "Error",
 					JOptionPane.ERROR_MESSAGE);
 			return null;
-		} finally {
-			try {
-				Conexion.cerrarConexion(cn, rset, stm);
-			} catch (SQLException er) {
-				er.printStackTrace();
-			} catch (Exception er) {
-				er.printStackTrace();
-			}
 		}
 	}
 

--- a/src/main/java/com/kathsoft/kathpos/app/controller/ArticuloController.java
+++ b/src/main/java/com/kathsoft/kathpos/app/controller/ArticuloController.java
@@ -54,10 +54,6 @@ public class ArticuloController implements java.io.Serializable {
 
 		return articulos;
 	}
-		
-	public Vector<Object[]> verArticulosEnTabla(int idSucursal, String textoBusqueda, int idTipoCliente){
-		return this.verArticulosEnTabla(idSucursal, "TODOS", "NOMBRE", textoBusqueda, idTipoCliente);
-	}
 
 	public Vector<Object[]> verArticulosEnTabla(int idSucursal, String tipoBusqueda, String ordenarPor,
 			String textoBusqueda, int idTipoCliente) {

--- a/src/main/java/com/kathsoft/kathpos/app/controller/ArticuloController.java
+++ b/src/main/java/com/kathsoft/kathpos/app/controller/ArticuloController.java
@@ -25,6 +25,10 @@ public class ArticuloController implements java.io.Serializable {
 	public Vector<Object[]> verArticulosEnTabla(int idSucursal, int idTipoCliente) {
 		return this.verArticulosEnTabla(idSucursal, "TODOS", "NOMBRE", "", idTipoCliente);
 	}
+		
+	public Vector<Object[]> verArticulosEnTabla(int idSucursal, String textoBusqueda, int idTipoCliente){
+		return this.verArticulosEnTabla(idSucursal, "TODOS", "NOMBRE", textoBusqueda, idTipoCliente);
+	}
 
 	public Vector<Object[]> verArticulosEnTabla(int idSucursal, String tipoBusqueda, String ordenarPor,
 			String textoBusqueda, int idTipoCliente) {

--- a/src/main/java/com/kathsoft/kathpos/app/model/articulo/ArticuloByCodigo.java
+++ b/src/main/java/com/kathsoft/kathpos/app/model/articulo/ArticuloByCodigo.java
@@ -1,129 +1,33 @@
 package com.kathsoft.kathpos.app.model.articulo;
 
-import java.util.Objects;
+public class ArticuloByCodigo extends Articulo {
 
-public class ArticuloByCodigo {
-
-	private int idArticulo;
-	private int idProveedor;
-	private int idCategoria;
-	private String codigoArticulo;
-	private String codigoSat;
-	private String unidadSat;
-	private String nombre;
-	private String descripcion;
-	private boolean exento;
-	private double costoUnitario;
-	private boolean activo;
+	private static final long serialVersionUID = 1L;
 	private int existencia;
 
 	public ArticuloByCodigo(int idArticulo, int idProveedor, int idCategoria, String codigoArticulo, String codigoSat,
 			String unidadSat, String nombre, String descripcion, boolean exento, double costoUnitario, boolean activo,
 			int existencia) {
-		super();
-		this.idArticulo = idArticulo;
-		this.idProveedor = idProveedor;
-		this.idCategoria = idCategoria;
-		this.codigoArticulo = codigoArticulo;
-		this.codigoSat = codigoSat;
-		this.unidadSat = unidadSat;
-		this.nombre = nombre;
-		this.descripcion = descripcion;
-		this.exento = exento;
-		this.costoUnitario = costoUnitario;
-		this.activo = activo;
+		super(idArticulo, idProveedor, idCategoria, codigoArticulo, codigoSat, unidadSat, nombre, descripcion, exento,
+				costoUnitario);
+		this.setActivo(activo);
 		this.existencia = existencia;
 	}
 
 	public ArticuloByCodigo() {
+		super();
 	}
 
-	public int getIdArticulo() {
-		return idArticulo;
-	}
-
-	public void setIdArticulo(int idArticulo) {
-		this.idArticulo = idArticulo;
-	}
-
+	/**
+	 * Alias con la nomenclatura correcta para conservar la API específica de este
+	 * modelo. {@link Articulo} mantiene históricamente el método getIdProvedor().
+	 */
 	public int getIdProveedor() {
-		return idProveedor;
+		return this.getIdProvedor();
 	}
 
 	public void setIdProveedor(int idProveedor) {
-		this.idProveedor = idProveedor;
-	}
-
-	public int getIdCategoria() {
-		return idCategoria;
-	}
-
-	public void setIdCategoria(int idCategoria) {
-		this.idCategoria = idCategoria;
-	}
-
-	public String getCodigoArticulo() {
-		return codigoArticulo;
-	}
-
-	public void setCodigoArticulo(String codigoArticulo) {
-		this.codigoArticulo = codigoArticulo;
-	}
-
-	public String getCodigoSat() {
-		return codigoSat;
-	}
-
-	public void setCodigoSat(String codigoSat) {
-		this.codigoSat = codigoSat;
-	}
-
-	public String getUnidadSat() {
-		return unidadSat;
-	}
-
-	public void setUnidadSat(String unidadSat) {
-		this.unidadSat = unidadSat;
-	}
-
-	public String getNombre() {
-		return nombre;
-	}
-
-	public void setNombre(String nombre) {
-		this.nombre = nombre;
-	}
-
-	public String getDescripcion() {
-		return descripcion;
-	}
-
-	public void setDescripcion(String descripcion) {
-		this.descripcion = descripcion;
-	}
-
-	public boolean isExento() {
-		return exento;
-	}
-
-	public void setExento(boolean exento) {
-		this.exento = exento;
-	}
-
-	public double getCostoUnitario() {
-		return costoUnitario;
-	}
-
-	public void setCostoUnitario(double costoUnitario) {
-		this.costoUnitario = costoUnitario;
-	}
-
-	public boolean isActivo() {
-		return activo;
-	}
-
-	public void setActivo(boolean activo) {
-		this.activo = activo;
+		this.setIdProvedor(idProveedor);
 	}
 
 	public int getExistencia() {
@@ -135,36 +39,12 @@ public class ArticuloByCodigo {
 	}
 
 	@Override
-	public int hashCode() {
-		return Objects.hash(Boolean.valueOf(activo), codigoArticulo, codigoSat, Double.valueOf(costoUnitario),
-				descripcion, Boolean.valueOf(exento), Integer.valueOf(idArticulo), Integer.valueOf(idCategoria),
-				Integer.valueOf(idProveedor), nombre, unidadSat);
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		ArticuloByCodigo other = (ArticuloByCodigo) obj;
-		return activo == other.activo && Objects.equals(codigoArticulo, other.codigoArticulo)
-				&& Objects.equals(codigoSat, other.codigoSat)
-				&& Double.doubleToLongBits(costoUnitario) == Double.doubleToLongBits(other.costoUnitario)
-				&& Objects.equals(descripcion, other.descripcion) && exento == other.exento
-				&& idArticulo == other.idArticulo && idCategoria == other.idCategoria
-				&& idProveedor == other.idProveedor && Objects.equals(nombre, other.nombre)
-				&& Objects.equals(unidadSat, other.unidadSat);
-	}
-
-	@Override
 	public String toString() {
-		return "ArticuloByCodigo [idArticulo=" + idArticulo + ", idProveedor=" + idProveedor + ", idCategoria="
-				+ idCategoria + ", codigoArticulo=" + codigoArticulo + ", codigoSat=" + codigoSat + ", unidadSat="
-				+ unidadSat + ", nombre=" + nombre + ", descripcion=" + descripcion + ", exento=" + exento
-				+ ", costoUnitario=" + costoUnitario + ", activo=" + activo + "]";
+		return "ArticuloByCodigo [idArticulo=" + getIdArticulo() + ", idProveedor=" + getIdProveedor()
+				+ ", idCategoria=" + getIdCategoria() + ", codigoArticulo=" + getCodigoArticulo() + ", codigoSat="
+				+ getCodigoSat() + ", unidadSat=" + getUnidadSat() + ", nombre=" + getNombre() + ", descripcion="
+				+ getDescripcion() + ", exento=" + isExento() + ", costoUnitario=" + getCostoUnitario() + ", activo="
+				+ isActivo() + ", existencia=" + existencia + "]";
 	}
 
 }

--- a/src/main/java/com/kathsoft/kathpos/app/view/compras/Fr_DatosCompras.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/compras/Fr_DatosCompras.java
@@ -17,8 +17,10 @@ import java.awt.FlowLayout;
 import javax.swing.border.LineBorder;
 
 import com.kathsoft.kathpos.app.model.ArticulosPorVentas;
+import com.kathsoft.kathpos.app.model.articulo.ArticuloByCodigo;
 import com.kathsoft.kathpos.app.model.interfaces.IListadoArticulosAcciones;
 import com.kathsoft.kathpos.app.model.viewmodel.JComboboxDataViewModel;
+import com.kathsoft.kathpos.app.view.shared.Fr_ListaArticulos;
 import com.kathsoft.kathpos.tools.AppContext;
 import com.kathsoft.kathpos.tools.ConstantsConllections;
 import com.kathsoft.kathpos.tools.DataTools;
@@ -31,6 +33,7 @@ import javax.swing.JTextField;
 import javax.swing.LayoutStyle.ComponentPlacement;
 import javax.swing.JFormattedTextField;
 import javax.swing.JComboBox;
+import javax.swing.JOptionPane;
 import javax.swing.JRadioButton;
 import javax.swing.ButtonGroup;
 import javax.swing.border.BevelBorder;
@@ -44,6 +47,7 @@ public class Fr_DatosCompras extends JFrame implements IListadoArticulosAcciones
 	private static final long serialVersionUID = 1L;
 	private static final int COLUMNA_CANTIDAD = 2;
 	private int idSucursal;
+	private ArticuloByCodigo articuloConsultado;
 	private JPanel contentPane;
 	private JPanel panelSuperiorEtiqueta;
 	private JPanel panelCentralContenedor;
@@ -234,13 +238,16 @@ public class Fr_DatosCompras extends JFrame implements IListadoArticulosAcciones
 		this.lblArticulo = new JLabel("Articulo");
 		
 		this.btnAgregarArticulo = new JButton("Agregar");
+		this.btnAgregarArticulo.addActionListener(e -> this.agregarArticuloConsultado());
 		
 		this.txfNombreCodigoArticulo = new JTextField();
 		this.lblArticulo.setLabelFor(this.txfNombreCodigoArticulo);
 		this.txfNombreCodigoArticulo.setToolTipText("Ingresa el código del artículo para registrarlo o el nombre para consultar");
 		this.txfNombreCodigoArticulo.setColumns(10);
+		this.txfNombreCodigoArticulo.addActionListener(e -> this.buscarArticulo());
 		
 		this.btnBuscarArticulo = new JButton("Buscar");
+		this.btnBuscarArticulo.addActionListener(e -> this.buscarArticulo());
 		GroupLayout gl_panelInferiorConsultaArticulos = new GroupLayout(this.panelInferiorConsultaArticulos);
 		gl_panelInferiorConsultaArticulos.setHorizontalGroup(
 			gl_panelInferiorConsultaArticulos.createParallelGroup(Alignment.LEADING)
@@ -462,6 +469,82 @@ public class Fr_DatosCompras extends JFrame implements IListadoArticulosAcciones
 		}
 	}
 
+	private void buscarArticulo() {
+		String textoBusqueda = this.txfNombreCodigoArticulo.getText().trim();
+		this.articuloConsultado = null;
+
+		if (textoBusqueda.isEmpty()) {
+			this.abrirFormListaArticulos("");
+			return;
+		}
+
+		try {
+			ArticuloByCodigo articulo = AppContext.articuloController.consultarArticuloPorCodigo(textoBusqueda,
+					this.idSucursal);
+
+			if (articulo == null) {
+				return;
+			}
+
+			if (articulo.getIdArticulo() <= 0) {
+				this.abrirFormListaArticulos(textoBusqueda);
+				return;
+			}
+
+			this.articuloConsultado = articulo;
+			this.txfNombreCodigoArticulo.setText(articulo.getCodigoArticulo());
+		} catch (Exception er) {
+			er.printStackTrace(System.err);
+			JOptionPane.showMessageDialog(this, "Ha ocurrido un error al consultar el artículo: " + er.getMessage(),
+					"Error", JOptionPane.ERROR_MESSAGE);
+		}
+	}
+
+	private void agregarArticuloConsultado() {
+		if (this.articuloConsultado == null || this.articuloConsultado.getIdArticulo() <= 0) {
+			JOptionPane.showMessageDialog(this, "Primero debe buscar un artículo por código", "Atención",
+					JOptionPane.WARNING_MESSAGE);
+			return;
+		}
+
+		String cantidadIngresada = JOptionPane.showInputDialog(this, "Ingrese la cantidad de artículos");
+		if (cantidadIngresada == null) {
+			return;
+		}
+
+		try {
+			int cantidad = Integer.parseInt(cantidadIngresada.trim());
+			if (cantidad <= 0) {
+				throw new NumberFormatException("La cantidad debe ser mayor a cero");
+			}
+
+			double subtotal = this.articuloConsultado.getCostoUnitario() * cantidad;
+			this.modelTablaArticulosListados.addRow(new Object[] {
+					this.articuloConsultado.getCodigoArticulo(),
+					this.articuloConsultado.getDescripcion(),
+					cantidad,
+					this.articuloConsultado.getCostoUnitario(),
+					subtotal
+			});
+
+			this.articuloConsultado = null;
+			this.txfNombreCodigoArticulo.setText("");
+			this.txfNombreCodigoArticulo.requestFocusInWindow();
+		} catch (NumberFormatException er) {
+			JOptionPane.showMessageDialog(this, "Ingrese una cantidad entera mayor a cero", "Cantidad inválida",
+					JOptionPane.WARNING_MESSAGE);
+		}
+	}
+
+	private void abrirFormListaArticulos(String nombreArticulo) {
+		EventQueue.invokeLater(() -> {
+			Fr_ListaArticulos frame = new Fr_ListaArticulos(nombreArticulo, this.idSucursal, this);
+			frame.setLocationRelativeTo(this);
+			frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+			frame.setVisible(true);
+		});
+	}
+
 	/**
 	 * Obtiene el tipo de compra seleccionado en los radio buttons.
 	 *
@@ -480,7 +563,7 @@ public class Fr_DatosCompras extends JFrame implements IListadoArticulosAcciones
 
 	@Override
 	public void listarArticuloDesdeConsulta(Object[] articulo, ArticulosPorVentas art) {
-		// TODO Auto-generated method stub
+		// TODO Se implementará en la siguiente etapa del flujo de selección.
 		
 	}
 }

--- a/src/main/java/com/kathsoft/kathpos/app/view/shared/Fr_ListaArticulos.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/shared/Fr_ListaArticulos.java
@@ -26,14 +26,14 @@ import javax.swing.table.TableColumnModel;
 
 import com.kathsoft.kathpos.app.controller.ArticuloController;
 import com.kathsoft.kathpos.app.model.ArticulosPorVentas;
-import com.kathsoft.kathpos.app.model.articulo.Articulo;
+import com.kathsoft.kathpos.app.model.articulo.ArticuloByCodigo;
 import com.kathsoft.kathpos.app.model.interfaces.IListadoArticulosAcciones;
-import com.kathsoft.kathpos.app.view.ventas.Fr_PuntoDeVentas;
 import com.kathsoft.kathpos.tools.ConstantsConllections;
 
 public class Fr_ListaArticulos extends JFrame {
 
 	private static final long serialVersionUID = 1L;
+	private static final int ID_TIPO_CLIENTE_GENERAL = 1;
 	/**
 	 * 
 	 * 
@@ -129,6 +129,7 @@ public class Fr_ListaArticulos extends JFrame {
 		panelSuperiorBusqueda.add(txfNombreArticulo);
 		txfNombreArticulo.setColumns(40);
 		this.txfNombreArticulo.setMaximumSize(this.txfNombreArticulo.getPreferredSize());
+		this.txfNombreArticulo.setText(this.nombreArticulo);
 
 		horizontalStrut_1 = Box.createHorizontalStrut(20);
 		panelSuperiorBusqueda.add(horizontalStrut_1);
@@ -156,14 +157,10 @@ public class Fr_ListaArticulos extends JFrame {
 
 		this.modelTablaArticulos.addColumn("Id");
 		this.modelTablaArticulos.addColumn("Codigo");
-		this.modelTablaArticulos.addColumn("Proveedor");
-		this.modelTablaArticulos.addColumn("Categoría");
-		this.modelTablaArticulos.addColumn("Codigo Sat");
 		this.modelTablaArticulos.addColumn("Nombre");
-		this.modelTablaArticulos.addColumn("Descripción");
+		this.modelTablaArticulos.addColumn("Costo");
+		this.modelTablaArticulos.addColumn("Precio");
 		this.modelTablaArticulos.addColumn("Existencia");
-		this.modelTablaArticulos.addColumn("Precio G.");
-		this.modelTablaArticulos.addColumn("Precio M");
 
 		tablaArticulos = new JTable();
 		scrollPaneTablaArticulo.setViewportView(tablaArticulos);
@@ -218,11 +215,9 @@ public class Fr_ListaArticulos extends JFrame {
 	}
 
 	private void llenarTablaArticulos(String nombreArticulo) {
-		System.out.println(this.nombreArticulo);
-		this.modelTablaArticulos.getDataVector().removeAllElements();
-		this.tablaArticulos.updateUI();
-		/*this.articuloController.consultarArticulosPorNombre(nombreArticulo, this.modelTablaArticulos, 1,
-				this.idSucursal);*/
+		this.modelTablaArticulos.setRowCount(0);
+		this.articuloController.verArticulosEnTabla(this.idSucursal, nombreArticulo, ID_TIPO_CLIENTE_GENERAL)
+				.forEach(this.modelTablaArticulos::addRow);
 	}
 	
 	/**
@@ -231,7 +226,7 @@ public class Fr_ListaArticulos extends JFrame {
 	private void listarArticulo() {
 
 		int articuloSeleccionado = this.tablaArticulos.getSelectedRow();
-		Articulo articulo = new Articulo();
+		ArticuloByCodigo articulo = new ArticuloByCodigo();
 		int cantidad = 0;
 		double subtotal = 0;
 		
@@ -242,18 +237,21 @@ public class Fr_ListaArticulos extends JFrame {
 				return;
 			}
 
-			// var m = (DefaultTableModel) this.tablaArticulos.getModel();
 			articulo = this.articuloController.consultarArticuloPorCodigo(
-					(String) this.tablaArticulos.getValueAt(articuloSeleccionado, 1), this.idSucursal);
+					(String) this.tablaArticulos.getValueAt(articuloSeleccionado, 1), this.idSucursal,
+					ID_TIPO_CLIENTE_GENERAL);
+
+			if (articulo == null || articulo.getIdArticulo() <= 0) {
+				return;
+			}
+
 			System.out.println(articulo.toString());
 
 			cantidad = Integer.parseInt(JOptionPane.showInputDialog(this, "Ingrese la cantidad de articulos"));
-			//subtotal = articulo.getPrecioGeneral() * cantidad;
 						
 			Object[] fila = {
 				articulo.getCodigoArticulo(),
 				articulo.getDescripcion(),
-				//articulo.getPrecioGeneral(),
 				cantidad,
 				0,
 				subtotal

--- a/src/main/java/com/kathsoft/kathpos/app/view/shared/Fr_ListaArticulos.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/shared/Fr_ListaArticulos.java
@@ -150,20 +150,7 @@ public class Fr_ListaArticulos extends JFrame {
 		panelCentralTabla.setLayout(new BorderLayout(0, 0));
 
 		scrollPaneTablaArticulo = new JScrollPane();
-		panelCentralTabla.add(scrollPaneTablaArticulo);
-
-		this.modelTablaArticulos = new DefaultTableModel();
-
-		this.modelTablaArticulos.addColumn("Id");
-		this.modelTablaArticulos.addColumn("Codigo");
-		this.modelTablaArticulos.addColumn("Proveedor");
-		this.modelTablaArticulos.addColumn("Categoría");
-		this.modelTablaArticulos.addColumn("Codigo Sat");
-		this.modelTablaArticulos.addColumn("Nombre");
-		this.modelTablaArticulos.addColumn("Descripción");
-		this.modelTablaArticulos.addColumn("Existencia");
-		this.modelTablaArticulos.addColumn("Precio G.");
-		this.modelTablaArticulos.addColumn("Precio M");
+		panelCentralTabla.add(scrollPaneTablaArticulo);		
 
 		tablaArticulos = new JTable();
 		scrollPaneTablaArticulo.setViewportView(tablaArticulos);
@@ -225,6 +212,14 @@ public class Fr_ListaArticulos extends JFrame {
 				this.idSucursal);*/
 	}
 	
+	
+	
+	public void setModelTablaArticulos() {
+		
+		this.modelTablaArticulos = new DefaultTableModel();
+		
+	}
+
 	/**
 	 * inserta los articulos seleccionados en la tabla principal del formulario y calcula los totales de compra
 	 */

--- a/src/main/java/com/kathsoft/kathpos/tools/ConstantsConllections.java
+++ b/src/main/java/com/kathsoft/kathpos/tools/ConstantsConllections.java
@@ -79,16 +79,12 @@ public class ConstantsConllections implements java.io.Serializable{
 	/**
 	 * define el ancho de columnas de la tabla en el formulario de selección de articulos
 	 */
-	public static int[] tablaArticulosListadoColumnsWidth = { 40, /* id */
+	public static int[] tablaArticulosListadoColumnsWidth = { 50, /* id */
 			150, /* codigo */
-			200, /* proveedor */
-			180, /* categoría */
-			100, /* codigo sat */
-			300, /* Nombre */
-			450, /* descripcion */
-			100, /* Existencia */
-			100, /* Precio g */
-			100 /* Precio m */
+			300, /* nombre */
+			120, /* costo */
+			120, /* precio */
+			100 /* existencia */
 	};
 	
 	public static final int[] tablaVentasColumnsWidth = { 50, // i venta


### PR DESCRIPTION
## Resumen

Esta PR continúa el flujo inicial de artículos dentro del módulo de compras y parte de `dev`.

Se integra la consulta por código mediante el nuevo procedimiento `getArticuloByCodigo`, se habilita el listado auxiliar reducido de artículos y se conectan los eventos básicos de búsqueda/agregado en `Fr_DatosCompras`.

## Cambios

### `ArticuloController`

- `consultarArticuloPorCodigo(...)` ahora retorna `ArticuloByCodigo`.
- La consulta utiliza:

```sql
CALL getArticuloByCodigo(?,?,?);
```

- Se agrega una sobrecarga que permite indicar explícitamente `idTipoCliente`.
- La firma de dos parámetros conserva temporalmente `idTipoCliente = 1` para mantener compatibilidad con los consumidores actuales.
- Se agrega una sobrecarga de `verArticulosEnTabla(...)` orientada al formulario auxiliar que retorna únicamente:
  - ID
  - Código
  - Nombre
  - Costo
  - Precio
  - Existencia

### `ArticuloByCodigo`

- Se especializa desde `Articulo` y conserva el campo adicional `existencia`.
- Esto permite que consumidores existentes que trabajan con `Articulo` continúen siendo compatibles con el nuevo tipo de retorno.

### `Fr_ListaArticulos`

- La tabla se reduce a las columnas:
  - ID
  - Código
  - Nombre
  - Costo
  - Precio
  - Existencia
- Se implementa `llenarTablaArticulos(...)` utilizando la nueva sobrecarga de `ArticuloController.verArticulosEnTabla(...)`.
- El texto recibido en `nombreArticulo` se utiliza como filtro inicial por nombre.
- La selección por código utiliza `ArticuloByCodigo`.

### `Fr_DatosCompras`

Se implementa el flujo inicial solicitado:

1. `ENTER` sobre `txfNombreCodigoArticulo` ejecuta búsqueda exacta por código.
2. `btnBuscarArticulo` ejecuta la misma búsqueda.
3. Si el código existe, el artículo queda preparado para agregarse.
4. `btnAgregarArticulo` solicita la cantidad mediante `JOptionPane.showInputDialog(...)`.
5. El artículo encontrado por código se agrega a `tableArticulosListados` con:
   - código
   - descripción
   - cantidad
   - costo unitario
   - subtotal
6. Si el código no existe, se abre `Fr_ListaArticulos` usando el texto capturado como búsqueda por nombre.
7. Si el campo está vacío, se abre directamente `Fr_ListaArticulos` sin filtro.

No se implementa todavía el callback final de selección desde `Fr_ListaArticulos` hacia `Fr_DatosCompras`; se mantiene pendiente para la siguiente etapa tal como se indicó.

### Constantes

- Se ajusta `tablaArticulosListadoColumnsWidth` a las seis columnas actuales del formulario auxiliar.

## Archivos modificados

```text
src/main/java/com/kathsoft/kathpos/app/controller/ArticuloController.java
src/main/java/com/kathsoft/kathpos/app/model/articulo/ArticuloByCodigo.java
src/main/java/com/kathsoft/kathpos/app/view/compras/Fr_DatosCompras.java
src/main/java/com/kathsoft/kathpos/app/view/shared/Fr_ListaArticulos.java
src/main/java/com/kathsoft/kathpos/tools/ConstantsConllections.java
```

## Fuera de alcance

- Persistencia de la compra.
- Actualización de existencias al guardar.
- Eliminación de artículos del detalle.
- Recalcular totales globales del formulario.
- Actualización automática del subtotal cuando se edita la columna cantidad.
- Implementación final de `listarArticuloDesdeConsulta(...)` en el formulario padre.
- Modificaciones de layout o distribución visual.

## Dependencia de base de datos

Esta implementación requiere que `getArticuloByCodigo` exista en la base de datos con tres parámetros: código, sucursal y tipo de cliente.

`database/procedures.sql` no se modifica en esta PR porque el procedimiento fue indicado como ya creado en la BD.