### PR TITLE
test: validate purchase stored procedures and controller flow

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/tools/Conexion.java
+++ b/src/main/java/com/kathsoft/kathpos/tools/Conexion.java
@@ -41,9 +41,9 @@ public class Conexion {
 	/**
 	 * Establece la conexion al servidor de base de datos usando configuracion externa.
 	 * <p>
-	 * La configuracion puede venir de variables de entorno o del archivo local
-	 * {@code config/database.properties}. Las variables de entorno tienen prioridad
-	 * sobre el archivo de propiedades.
+	 * La configuracion puede venir de variables de entorno, propiedades de la JVM o
+	 * del archivo local {@code config/database.properties}. Las propiedades de la JVM
+	 * tienen prioridad, seguidas por las variables de entorno y el archivo local.
 	 *
 	 * @param nombreBBDD nombre de la base de datos a utilizar; si viene vacio se usa
 	 *                   la base configurada por defecto
@@ -85,6 +85,12 @@ public class Conexion {
 	}
 
 	private static String obtenerValorConfiguracion(String envName, String propertyName, String defaultValue) {
+		String systemValue = System.getProperty(propertyName);
+
+		if (systemValue != null && !systemValue.isBlank()) {
+			return systemValue.trim();
+		}
+
 		String envValue = System.getenv(envName);
 
 		if (envValue != null && !envValue.isBlank()) {

--- a/src/test/java/com/kathsoft/kathpos/integration/CompraControllerIT.java
+++ b/src/test/java/com/kathsoft/kathpos/integration/CompraControllerIT.java
@@ -1,0 +1,217 @@
+package com.kathsoft.kathpos.integration;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mysql.MySQLContainer;
+import org.testcontainers.utility.MountableFile;
+
+import com.kathsoft.kathpos.app.controller.CompraController;
+import com.kathsoft.kathpos.app.model.compra.ArticuloPorCompra;
+import com.kathsoft.kathpos.app.model.compra.Compra;
+import com.kathsoft.kathpos.app.model.compra.CompraById;
+import com.kathsoft.kathpos.app.model.compra.CompraConDetalle;
+import com.kathsoft.kathpos.app.model.viewmodel.SpResponseModel;
+
+@Testcontainers
+class CompraControllerIT {
+
+    private static final String DATABASE_NAME = "kath_erp";
+    private static final int ID_SUCURSAL_COMPRA = 1;
+    private static final int ID_SUCURSAL_CONTROL = 2;
+    private static final int ID_ARTICULO_EXISTENTE = 100;
+    private static final int ID_ARTICULO_NUEVO = 101;
+
+    @Container
+    private static final MySQLContainer MYSQL = new MySQLContainer("mysql:8.0.46")
+            .withDatabaseName(DATABASE_NAME)
+            .withUsername("kath_test")
+            .withPassword("kath_test")
+            .withCopyFileToContainer(
+                    MountableFile.forClasspathResource("db/init/schema.sql"),
+                    "/docker-entrypoint-initdb.d/01-schema.sql")
+            .withCopyFileToContainer(
+                    MountableFile.forClasspathResource("db/init/procedures.sql"),
+                    "/docker-entrypoint-initdb.d/02-procedures.sql")
+            .withCopyFileToContainer(
+                    MountableFile.forClasspathResource("db/fixtures/compra_minima.sql"),
+                    "/docker-entrypoint-initdb.d/03-compra-minima.sql");
+
+    @BeforeAll
+    static void configurarConexionDelControlador() {
+        System.setProperty("db.host", MYSQL.getHost());
+        System.setProperty("db.port", String.valueOf(MYSQL.getMappedPort(3306)));
+        System.setProperty("db.name", DATABASE_NAME);
+        System.setProperty("db.user", MYSQL.getUsername());
+        System.setProperty("db.password", MYSQL.getPassword());
+        System.setProperty("db.params", "serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true");
+    }
+
+    @AfterAll
+    static void limpiarConfiguracionDelControlador() {
+        System.clearProperty("db.host");
+        System.clearProperty("db.port");
+        System.clearProperty("db.name");
+        System.clearProperty("db.user");
+        System.clearProperty("db.password");
+        System.clearProperty("db.params");
+    }
+
+    @BeforeEach
+    void prepararExistenciasIniciales() throws SQLException {
+        try (Connection connection = nuevaConexion(); Statement statement = connection.createStatement()) {
+            statement.executeUpdate("DELETE FROM articulo_x_compra");
+            statement.executeUpdate("DELETE FROM existencia_x_sucursal");
+            statement.executeUpdate("DELETE FROM compras");
+            statement.executeUpdate("""
+                    INSERT INTO existencia_x_sucursal (id_articulo, id_sucursal, existencia)
+                    VALUES (100, 1, 5), (100, 2, 40), (101, 2, 25)
+                    """);
+        }
+    }
+
+    @Test
+    void registraCompraCompletaConDetallesExistenciasYTotalCorrectos() throws SQLException {
+        CompraController controller = new CompraController();
+        ArticuloPorCompra articuloExistente = crearDetalle(ID_ARTICULO_EXISTENTE, 2, 200.00);
+        ArticuloPorCompra articuloNuevo = crearDetalle(ID_ARTICULO_NUEVO, 3, 150.00);
+        CompraConDetalle compra = new CompraConDetalle(
+                crearCompra("FAC-CTRL-001", 350.00, 56.00),
+                List.of(articuloExistente, articuloNuevo));
+
+        SpResponseModel respuesta = controller.insertCompra(ID_SUCURSAL_COMPRA, compra);
+
+        assertAll(
+                () -> assertTrue(respuesta.id() > 0, respuesta.message()),
+                () -> assertEquals("Compra registrada correctamente", respuesta.message()),
+                () -> assertEquals(respuesta.id(), articuloExistente.getIdCompra()),
+                () -> assertEquals(respuesta.id(), articuloNuevo.getIdCompra()));
+
+        CompraById compraConsultada = controller.getCompraById(respuesta.id());
+        assertNotNull(compraConsultada);
+        assertAll(
+                () -> assertEquals("FAC-CTRL-001", compraConsultada.getFolioFactura()),
+                () -> assertEquals(350.00, compraConsultada.getSubtotal(), 0.001),
+                () -> assertEquals(56.00, compraConsultada.getIva(), 0.001),
+                () -> assertEquals(406.00, compraConsultada.getImporteTotal(), 0.001));
+
+        assertAll(
+                () -> assertEquals(1, consultarEntero(
+                        "SELECT COUNT(*) FROM compras WHERE id_compra = ? AND id_sucursal = ?",
+                        respuesta.id(), ID_SUCURSAL_COMPRA)),
+                () -> assertEquals(2, consultarEntero(
+                        "SELECT COUNT(*) FROM articulo_x_compra WHERE id_compra = ?",
+                        respuesta.id())),
+                () -> assertEquals(350.00, consultarDouble(
+                        "SELECT SUM(subtotal) FROM articulo_x_compra WHERE id_compra = ?",
+                        respuesta.id()), 0.001),
+                () -> assertEquals(2, consultarEntero(
+                        "SELECT cantidad FROM articulo_x_compra WHERE id_compra = ? AND id_articulo = ?",
+                        respuesta.id(), ID_ARTICULO_EXISTENTE)),
+                () -> assertEquals(3, consultarEntero(
+                        "SELECT cantidad FROM articulo_x_compra WHERE id_compra = ? AND id_articulo = ?",
+                        respuesta.id(), ID_ARTICULO_NUEVO)));
+
+        assertAll(
+                () -> assertEquals(7, consultarExistencia(ID_ARTICULO_EXISTENTE, ID_SUCURSAL_COMPRA)),
+                () -> assertEquals(3, consultarExistencia(ID_ARTICULO_NUEVO, ID_SUCURSAL_COMPRA)),
+                () -> assertEquals(40, consultarExistencia(ID_ARTICULO_EXISTENTE, ID_SUCURSAL_CONTROL)),
+                () -> assertEquals(25, consultarExistencia(ID_ARTICULO_NUEVO, ID_SUCURSAL_CONTROL)));
+    }
+
+    @Test
+    void revierteTodaLaCompraCuandoFallaUnoDeLosDetalles() throws SQLException {
+        CompraController controller = new CompraController();
+        CompraConDetalle compra = new CompraConDetalle(
+                crearCompra("FAC-CTRL-002", 300.00, 48.00),
+                List.of(
+                        crearDetalle(ID_ARTICULO_EXISTENTE, 2, 200.00),
+                        crearDetalle(999_999, 1, 100.00)));
+
+        SpResponseModel respuesta = controller.insertCompra(ID_SUCURSAL_COMPRA, compra);
+
+        assertAll(
+                () -> assertEquals(500, respuesta.id()),
+                () -> assertTrue(respuesta.message().contains("no existe o está inactivo")),
+                () -> assertEquals(0, consultarEntero(
+                        "SELECT COUNT(*) FROM compras WHERE folio_factura = ?", "FAC-CTRL-002")),
+                () -> assertEquals(0, consultarEntero("SELECT COUNT(*) FROM articulo_x_compra")),
+                () -> assertEquals(5, consultarExistencia(ID_ARTICULO_EXISTENTE, ID_SUCURSAL_COMPRA)),
+                () -> assertEquals(40, consultarExistencia(ID_ARTICULO_EXISTENTE, ID_SUCURSAL_CONTROL)));
+    }
+
+    private Compra crearCompra(String folio, double subtotal, double iva) {
+        return new Compra.CompraBuilder()
+                .idEmpleado(1)
+                .idProveedor(1)
+                .folioFactura(folio)
+                .fechaFactura(Date.valueOf("2026-08-20"))
+                .fechaCompra(Date.valueOf("2026-08-21"))
+                .tipoCompra(false)
+                .subtotal(subtotal)
+                .iva(iva)
+                .build();
+    }
+
+    private ArticuloPorCompra crearDetalle(int idArticulo, int cantidad, double subtotal) {
+        return new ArticuloPorCompra.ArticuloPorCompraBuilder()
+                .idArticulo(idArticulo)
+                .cantidad(cantidad)
+                .subtotal(subtotal)
+                .build();
+    }
+
+    private Connection nuevaConexion() throws SQLException {
+        return DriverManager.getConnection(MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword());
+    }
+
+    private int consultarExistencia(int idArticulo, int idSucursal) throws SQLException {
+        return consultarEntero(
+                "SELECT existencia FROM existencia_x_sucursal WHERE id_articulo = ? AND id_sucursal = ?",
+                idArticulo, idSucursal);
+    }
+
+    private int consultarEntero(String sql, Object... parametros) throws SQLException {
+        try (Connection connection = nuevaConexion();
+                PreparedStatement statement = prepararConsulta(connection, sql, parametros);
+                ResultSet resultSet = statement.executeQuery()) {
+            assertTrue(resultSet.next(), "La consulta debe devolver una fila: " + sql);
+            return resultSet.getInt(1);
+        }
+    }
+
+    private double consultarDouble(String sql, Object... parametros) throws SQLException {
+        try (Connection connection = nuevaConexion();
+                PreparedStatement statement = prepararConsulta(connection, sql, parametros);
+                ResultSet resultSet = statement.executeQuery()) {
+            assertTrue(resultSet.next(), "La consulta debe devolver una fila: " + sql);
+            return resultSet.getDouble(1);
+        }
+    }
+
+    private PreparedStatement prepararConsulta(Connection connection, String sql, Object... parametros)
+            throws SQLException {
+        PreparedStatement statement = connection.prepareStatement(sql);
+        for (int index = 0; index < parametros.length; index++) {
+            statement.setObject(index + 1, parametros[index]);
+        }
+        return statement;
+    }
+}

--- a/src/test/resources/db/fixtures/compra_minima.sql
+++ b/src/test/resources/db/fixtures/compra_minima.sql
@@ -74,18 +74,31 @@ INSERT INTO sucursal (
     direccion,
     codigo_postal,
     activo
-) VALUES (
-    1,
-    'Sucursal de pruebas',
-    'Sucursal ficticia para pruebas de integración',
-    '9610000000',
-    'sucursal@kath.test',
-    'Chiapas',
-    'Tuxtla Gutiérrez',
-    'Dirección ficticia 1',
-    '29000',
-    TRUE
-);
+) VALUES
+    (
+        1,
+        'Sucursal de pruebas',
+        'Sucursal ficticia para pruebas de integración',
+        '9610000000',
+        'sucursal@kath.test',
+        'Chiapas',
+        'Tuxtla Gutiérrez',
+        'Dirección ficticia 1',
+        '29000',
+        TRUE
+    ),
+    (
+        2,
+        'Sucursal de control',
+        'Sucursal usada para comprobar aislamiento de existencias',
+        '9610000001',
+        'sucursal-control@kath.test',
+        'Chiapas',
+        'Tuxtla Gutiérrez',
+        'Dirección ficticia 4',
+        '29000',
+        TRUE
+    );
 
 INSERT INTO empleados (
     id_empleado,
@@ -171,16 +184,30 @@ INSERT INTO articulo (
     es_exento,
     costo_unitario,
     activo
-) VALUES (
-    100,
-    1,
-    1,
-    'ART-IT-001',
-    '01010101',
-    'H87',
-    'Artículo de integración',
-    'Artículo ficticio para pruebas de integración',
-    FALSE,
-    100.00,
-    TRUE
-);
+) VALUES
+    (
+        100,
+        1,
+        1,
+        'ART-IT-001',
+        '01010101',
+        'H87',
+        'Artículo de integración',
+        'Artículo ficticio para pruebas de integración',
+        FALSE,
+        100.00,
+        TRUE
+    ),
+    (
+        101,
+        1,
+        1,
+        'ART-IT-002',
+        '01010101',
+        'H87',
+        'Segundo artículo de integración',
+        'Artículo ficticio para probar compras con varios detalles',
+        FALSE,
+        50.00,
+        TRUE
+    );


### PR DESCRIPTION
## Resumen

- incorpora `database/schema.sql` y `database/procedures.sql` como fuente versionada para pruebas
- agrega MySQL 8 con Testcontainers y datos ficticios mínimos
- prueba directamente los procedimientos de compra y su comportamiento transaccional
- prueba el flujo real de `CompraController.insertCompra`
- verifica cabecera, detalles, existencias por sucursal, total y rollback completo
- permite configurar `Conexion` mediante propiedades JVM para aislar la base desechable

## Escenarios cubiertos

- carga de procedimientos vigentes
- registro válido y rechazo de folio duplicado
- registro de compra con dos detalles
- incremento de existencia previa y creación de una nueva
- aislamiento de existencias entre sucursales
- subtotal de detalles, IVA e importe total
- rollback cuando un detalle es inválido

## Verificación

El workflow `Database integration tests` ejecuta:

```shell
./mvnw --batch-mode --no-transfer-progress verify
```

No fue posible ejecutar Testcontainers en el entorno local de trabajo porque no dispone de Docker ni Java 21. La validación completa queda a cargo de GitHub Actions antes de integrar.

## Decisión pendiente

Actualmente el subtotal e IVA llegan calculados al controlador. Todavía no se rechaza una compra cuando el subtotal de cabecera difiere de la suma de sus detalles; esa regla de negocio debe definirse antes de añadir esa validación.