### PR TITLE
feat(compras): completa eventos de partidas y recalculo de importes

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/controller/CompraController.java
+++ b/src/main/java/com/kathsoft/kathpos/app/controller/CompraController.java
@@ -28,6 +28,13 @@ public class CompraController implements java.io.Serializable {
 		return this.listCompras(idSucursal, new CompraFiltro());
 	}
 
+	public int getSiguienteIdCompra(int idSucursal) {
+		return this.listCompras(idSucursal).stream()
+				.mapToInt(CompraListado::getIdCompra)
+				.max()
+				.orElse(0) + 1;
+	}
+
 	public List<CompraListado> listCompras(int idSucursal, CompraFiltro filtro) {
 		CallableStatement stm = null;
 		ResultSet rset = null;

--- a/src/main/java/com/kathsoft/kathpos/app/view/compras/Fr_DatosCompras.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/compras/Fr_DatosCompras.java
@@ -6,14 +6,20 @@ import java.awt.Color;
 import java.awt.Font;
 import java.awt.FlowLayout;
 import java.awt.GridLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
 import java.math.BigDecimal;
 import java.text.ParseException;
+import java.util.HashMap;
+import java.util.Map;
 
+import javax.swing.AbstractAction;
 import javax.swing.BoxLayout;
 import javax.swing.ButtonGroup;
 import javax.swing.DefaultCellEditor;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
+import javax.swing.JComponent;
 import javax.swing.JFormattedTextField;
 import javax.swing.JFrame;
 import javax.swing.GroupLayout;
@@ -25,11 +31,13 @@ import javax.swing.JRadioButton;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
+import javax.swing.KeyStroke;
 import javax.swing.LayoutStyle.ComponentPlacement;
 import javax.swing.border.BevelBorder;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.LineBorder;
 import javax.swing.border.TitledBorder;
+import javax.swing.event.TableModelEvent;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.text.MaskFormatter;
 
@@ -45,10 +53,15 @@ import com.kathsoft.kathpos.tools.DataTools;
 public class Fr_DatosCompras extends JFrame implements IListadoArticulosAcciones{
 
 	private static final long serialVersionUID = 1L;
+	private static final int COLUMNA_CODIGO = 0;
 	private static final int COLUMNA_CANTIDAD = 2;
-	private static final double TASA_IVA = 0.16;
+	private static final int COLUMNA_COSTO_UNITARIO = 3;
+	private static final int COLUMNA_SUBTOTAL = 4;
+	private static final double FACTOR_IVA = 1.16;
 	private int idSucursal;
 	private ArticuloByCodigo articuloConsultado;
+	private Map<String, ArticuloByCodigo> articulosPorCodigo;
+	private boolean actualizandoImportes;
 	private double subtotalCompra;
 	private double ivaCompra;
 	private JPanel contentPane;
@@ -100,6 +113,7 @@ public class Fr_DatosCompras extends JFrame implements IListadoArticulosAcciones
 	 * Create the frame.
 	 */
 	public Fr_DatosCompras() {
+		this.articulosPorCodigo = new HashMap<>();
 		setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 		setBounds(100, 100, 836, 630);
 		this.contentPane = new JPanel();
@@ -154,6 +168,7 @@ public class Fr_DatosCompras extends JFrame implements IListadoArticulosAcciones
 		);
 		
 		this.btnEliminarArticuloSeleccionado = new JButton("Quitar Articulo");
+		this.btnEliminarArticuloSeleccionado.addActionListener(e -> this.eliminarArticuloSeleccionado());
 		
 		this.lblSubTotal = new JLabel("Sub Total");
 		
@@ -237,6 +252,7 @@ public class Fr_DatosCompras extends JFrame implements IListadoArticulosAcciones
 		DataTools.definirTamanioDeColumnas(ConstantsConllections.tablaArticulosCompraColumnsWidth,
 				this.tableArticulosListados);
 		this.configurarEditoresTablaArticulos();
+		this.configurarEventosTablaArticulos();
 		
 		this.lblArticulo = new JLabel("Articulo");
 		
@@ -247,7 +263,7 @@ public class Fr_DatosCompras extends JFrame implements IListadoArticulosAcciones
 		this.lblArticulo.setLabelFor(this.txfNombreCodigoArticulo);
 		this.txfNombreCodigoArticulo.setToolTipText("Ingresa el código del artículo para registrarlo o el nombre para consultar");
 		this.txfNombreCodigoArticulo.setColumns(10);
-		this.txfNombreCodigoArticulo.addActionListener(e -> this.buscarArticulo());
+		this.txfNombreCodigoArticulo.addActionListener(e -> this.procesarEnterArticulo());
 		
 		this.btnBuscarArticulo = new JButton("Buscar");
 		this.btnBuscarArticulo.addActionListener(e -> this.buscarArticulo());
@@ -444,6 +460,7 @@ public class Fr_DatosCompras extends JFrame implements IListadoArticulosAcciones
 		this();
 		this.idSucursal = idSucursal;
 		this.llenarComboBoxEmpleado();
+		this.cargarSiguienteIdCompra();
 	}
 
 	private void llenarComboBoxProveedor() {
@@ -458,6 +475,13 @@ public class Fr_DatosCompras extends JFrame implements IListadoArticulosAcciones
 		}
 		AppContext.empleadoController.consultaNombresCortosEmpleados(this.idSucursal)
 				.forEach(this.comboBoxEmpleado::addItem);
+	}
+
+	private void cargarSiguienteIdCompra() {
+		if (this.idSucursal <= 0) {
+			return;
+		}
+		this.txfIdCompra.setText(String.valueOf(AppContext.compraController.getSiguienteIdCompra(this.idSucursal)));
 	}
 
 	private MaskFormatter buildDateFormatter() {
@@ -476,6 +500,39 @@ public class Fr_DatosCompras extends JFrame implements IListadoArticulosAcciones
 		DefaultCellEditor editorCantidad = new DefaultCellEditor(new JTextField());
 		this.tableArticulosListados.setDefaultEditor(Object.class, null);
 		this.tableArticulosListados.getColumnModel().getColumn(COLUMNA_CANTIDAD).setCellEditor(editorCantidad);
+	}
+
+	private void configurarEventosTablaArticulos() {
+		this.modelTablaArticulosListados.addTableModelListener(event -> {
+			if (this.actualizandoImportes || event.getType() != TableModelEvent.UPDATE
+					|| event.getColumn() != COLUMNA_CANTIDAD) {
+				return;
+			}
+			this.recalcularImportesDesdeTabla(true);
+		});
+
+		String accionEliminar = "eliminarArticuloCompra";
+		this.tableArticulosListados.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT)
+				.put(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0), accionEliminar);
+		this.tableArticulosListados.getActionMap().put(accionEliminar, new AbstractAction() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				if (tableArticulosListados.getSelectedRow() >= 0
+						&& tableArticulosListados.getSelectedColumn() == COLUMNA_CODIGO) {
+					eliminarArticuloSeleccionado();
+				}
+			}
+		});
+	}
+
+	private void procesarEnterArticulo() {
+		if (this.articuloConsultado != null && this.articuloConsultado.getIdArticulo() > 0) {
+			this.agregarArticuloConsultado();
+			return;
+		}
+		this.buscarArticulo();
 	}
 
 	private void buscarArticulo() {
@@ -549,20 +606,103 @@ public class Fr_DatosCompras extends JFrame implements IListadoArticulosAcciones
 			return;
 		}
 
-		double subtotalArticulo = articulo.getCostoUnitario() * cantidad;
+		double importeArticulo = articulo.getCostoUnitario() * cantidad;
+		this.articulosPorCodigo.put(articulo.getCodigoArticulo(), articulo);
 		this.modelTablaArticulosListados.addRow(new Object[] {
 				articulo.getCodigoArticulo(),
 				articulo.getDescripcion(),
 				cantidad,
 				articulo.getCostoUnitario(),
-				subtotalArticulo
+				importeArticulo
 		});
+		this.recalcularImportesDesdeTabla(false);
+	}
 
-		this.subtotalCompra += subtotalArticulo;
-		if (!articulo.isExento()) {
-			this.ivaCompra += subtotalArticulo * TASA_IVA;
+	private void eliminarArticuloSeleccionado() {
+		int filaSeleccionada = this.tableArticulosListados.getSelectedRow();
+		if (filaSeleccionada < 0) {
+			JOptionPane.showMessageDialog(this, "Seleccione un artículo para eliminar", "Atención",
+					JOptionPane.WARNING_MESSAGE);
+			return;
 		}
-		this.actualizarTotalesCompra();
+
+		if (this.tableArticulosListados.isEditing() && this.tableArticulosListados.getCellEditor() != null) {
+			this.tableArticulosListados.getCellEditor().stopCellEditing();
+		}
+
+		int filaModelo = this.tableArticulosListados.convertRowIndexToModel(filaSeleccionada);
+		this.modelTablaArticulosListados.removeRow(filaModelo);
+		this.recalcularImportesDesdeTabla(false);
+	}
+
+	private void recalcularImportesDesdeTabla(boolean mostrarErrorCantidad) {
+		if (this.actualizandoImportes) {
+			return;
+		}
+
+		this.actualizandoImportes = true;
+		try {
+			int totalFilas = this.modelTablaArticulosListados.getRowCount();
+			double[] importes = new double[totalFilas];
+			double nuevoSubtotal = 0;
+			double nuevoIva = 0;
+
+			for (int fila = 0; fila < totalFilas; fila++) {
+				int cantidad = this.obtenerCantidadFila(fila);
+				double costoUnitario = this.obtenerDoubleFila(fila, COLUMNA_COSTO_UNITARIO);
+				double importeConIva = costoUnitario * cantidad;
+				importes[fila] = importeConIva;
+
+				String codigo = String.valueOf(this.modelTablaArticulosListados.getValueAt(fila, COLUMNA_CODIGO));
+				ArticuloByCodigo articulo = this.articulosPorCodigo.get(codigo);
+				boolean exento = articulo != null && articulo.isExento();
+
+				if (exento) {
+					nuevoSubtotal += importeConIva;
+				} else {
+					double baseGravada = importeConIva / FACTOR_IVA;
+					nuevoSubtotal += baseGravada;
+					nuevoIva += importeConIva - baseGravada;
+				}
+			}
+
+			for (int fila = 0; fila < totalFilas; fila++) {
+				this.modelTablaArticulosListados.setValueAt(importes[fila], fila, COLUMNA_SUBTOTAL);
+			}
+
+			this.subtotalCompra = nuevoSubtotal;
+			this.ivaCompra = nuevoIva;
+			this.actualizarTotalesCompra();
+		} catch (NumberFormatException er) {
+			if (mostrarErrorCantidad) {
+				JOptionPane.showMessageDialog(this, "La cantidad debe ser un número entero mayor a cero",
+						"Cantidad inválida", JOptionPane.WARNING_MESSAGE);
+			}
+		} finally {
+			this.actualizandoImportes = false;
+		}
+	}
+
+	private int obtenerCantidadFila(int fila) {
+		Object valor = this.modelTablaArticulosListados.getValueAt(fila, COLUMNA_CANTIDAD);
+		int cantidad;
+		if (valor instanceof Number numero) {
+			cantidad = numero.intValue();
+		} else {
+			cantidad = Integer.parseInt(String.valueOf(valor).trim());
+		}
+		if (cantidad <= 0) {
+			throw new NumberFormatException("La cantidad debe ser mayor a cero");
+		}
+		return cantidad;
+	}
+
+	private double obtenerDoubleFila(int fila, int columna) {
+		Object valor = this.modelTablaArticulosListados.getValueAt(fila, columna);
+		if (valor instanceof Number numero) {
+			return numero.doubleValue();
+		}
+		return Double.parseDouble(String.valueOf(valor).trim());
 	}
 
 	private void actualizarTotalesCompra() {

--- a/src/main/java/com/kathsoft/kathpos/app/view/shared/Fr_ListaArticulos.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/shared/Fr_ListaArticulos.java
@@ -6,11 +6,14 @@ import java.awt.Component;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
 import java.math.BigDecimal;
 
+import javax.swing.AbstractAction;
 import javax.swing.Box;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
+import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
@@ -18,6 +21,7 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
+import javax.swing.KeyStroke;
 import javax.swing.border.BevelBorder;
 import javax.swing.border.CompoundBorder;
 import javax.swing.border.EmptyBorder;
@@ -128,6 +132,7 @@ public class Fr_ListaArticulos extends JFrame {
 		scrollPaneTablaArticulo.setViewportView(tablaArticulos);
 		tablaArticulos.setModel(this.modelTablaArticulos);
 		tablaArticulos.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
+		this.configurarEnterTablaArticulos();
 
 		panelInferiorBotones = new JPanel();
 		panelInferiorBotones.setBorder(new CompoundBorder(new BevelBorder(BevelBorder.LOWERED, null, null, null, null),
@@ -167,6 +172,20 @@ public class Fr_ListaArticulos extends JFrame {
 		}
 
 		this.llenarTablaArticulos(this.nombreArticulo);
+	}
+
+	private void configurarEnterTablaArticulos() {
+		String accionSeleccionar = "seleccionarArticulo";
+		this.tablaArticulos.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT)
+				.put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), accionSeleccionar);
+		this.tablaArticulos.getActionMap().put(accionSeleccionar, new AbstractAction() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				listarArticulo();
+			}
+		});
 	}
 
 	private void llenarTablaArticulos(String nombreArticulo) {

--- a/src/main/java/com/kathsoft/kathpos/app/view/shared/Fr_ListaArticulos.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/shared/Fr_ListaArticulos.java
@@ -7,6 +7,8 @@ import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.math.BigDecimal;
 
 import javax.swing.AbstractAction;
@@ -29,8 +31,10 @@ import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableColumnModel;
 
 import com.kathsoft.kathpos.app.controller.ArticuloController;
+import com.kathsoft.kathpos.app.model.articulo.Articulo;
 import com.kathsoft.kathpos.app.model.articulo.ArticuloByCodigo;
 import com.kathsoft.kathpos.app.model.interfaces.IListadoArticulosAcciones;
+import com.kathsoft.kathpos.app.view.articulo.Fr_DatosArticulo;
 import com.kathsoft.kathpos.tools.ConstantsConllections;
 
 public class Fr_ListaArticulos extends JFrame {
@@ -213,11 +217,14 @@ public class Fr_ListaArticulos extends JFrame {
 		}
 
 		try {
-			String codigoArticulo = String.valueOf(this.tablaArticulos.getValueAt(articuloSeleccionado, 1));
+			int filaModelo = this.tablaArticulos.convertRowIndexToModel(articuloSeleccionado);
+			int idArticulo = this.obtenerIdArticuloSeleccionado(filaModelo);
+			String codigoArticulo = String.valueOf(this.modelTablaArticulos.getValueAt(filaModelo, 1));
 			ArticuloByCodigo articulo = this.articuloController.consultarArticuloPorCodigo(codigoArticulo,
 					this.idSucursal, ID_TIPO_CLIENTE_GENERAL);
 
 			if (articulo == null || articulo.getIdArticulo() <= 0) {
+				this.manejarArticuloNoDisponible(idArticulo);
 				return;
 			}
 
@@ -231,7 +238,7 @@ public class Fr_ListaArticulos extends JFrame {
 				throw new NumberFormatException("La cantidad debe ser mayor a cero");
 			}
 
-			BigDecimal precio = this.obtenerPrecioSeleccionado(articuloSeleccionado);
+			BigDecimal precio = this.obtenerPrecioSeleccionado(filaModelo);
 			this.frame.listarArticuloDesdeConsulta(articulo, cantidad, precio);
 			this.dispose();
 		} catch (NumberFormatException er) {
@@ -244,8 +251,54 @@ public class Fr_ListaArticulos extends JFrame {
 		}
 	}
 
+	private int obtenerIdArticuloSeleccionado(int filaModelo) {
+		Object valor = this.modelTablaArticulos.getValueAt(filaModelo, 0);
+		if (valor instanceof Number numero) {
+			return numero.intValue();
+		}
+		try {
+			return Integer.parseInt(String.valueOf(valor));
+		} catch (NumberFormatException er) {
+			return 0;
+		}
+	}
+
+	private void manejarArticuloNoDisponible(int idArticulo) throws Exception {
+		if (idArticulo <= 0) {
+			return;
+		}
+
+		Articulo articulo = this.articuloController.consultarArticuloPorId(idArticulo, this.idSucursal);
+		if (articulo == null || articulo.getIdArticulo() <= 0 || articulo.isActivo()) {
+			return;
+		}
+
+		int opcion = JOptionPane.showConfirmDialog(this,
+				"Articulo seleccionado está inactivo o dado de baja.\n¿Habilitar nuevamente?", "Articulo inactivo",
+				JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+		if (opcion != JOptionPane.YES_OPTION) {
+			return;
+		}
+
+		this.abrirFormularioArticuloInactivo(idArticulo);
+	}
+
+	private void abrirFormularioArticuloInactivo(int idArticulo) {
+		Fr_DatosArticulo form = new Fr_DatosArticulo(1, idArticulo, this.idSucursal);
+		form.setLocationRelativeTo(this);
+		form.addWindowListener(new WindowAdapter() {
+			@Override
+			public void windowClosed(WindowEvent e) {
+				if (form.isOperacionEjecutada()) {
+					llenarTablaArticulos(txfNombreArticulo.getText());
+				}
+			}
+		});
+		form.setVisible(true);
+	}
+
 	private BigDecimal obtenerPrecioSeleccionado(int fila) {
-		Object valor = this.tablaArticulos.getValueAt(fila, 4);
+		Object valor = this.modelTablaArticulos.getValueAt(fila, 4);
 		if (valor == null) {
 			return BigDecimal.ZERO;
 		}


### PR DESCRIPTION
## Resumen

Completa las interacciones previas al guardado de compras: identificación preliminar de la siguiente compra, flujo por teclado para artículos, eliminación de partidas, recálculo automático de importes y manejo explícito de artículos inactivos.

## Cambios

### `CompraController`

- Agrega `getSiguienteIdCompra(int idSucursal)`.
- Usa el listado actual de compras de la sucursal y obtiene el mayor `idCompra` para retornar `max + 1`.

### `Fr_DatosCompras`

- Al construir el formulario con `idSucursal`, carga en `txfIdCompra` el siguiente ID calculado por `CompraController`.
- Se conserva la búsqueda por código en `txfNombreCodigoArticulo`.
- Después de una búsqueda positiva, el campo muestra el nombre del artículo.
- Si se presiona `ENTER` nuevamente mientras `ArticuloByCodigo` sigue disponible, se ejecuta inmediatamente el flujo para solicitar cantidad y agregar la partida.
- `btnEliminarArticuloSeleccionado` elimina la fila seleccionada y recalcula importes.
- La tecla `Supr` ejecuta la misma eliminación cuando la celda seleccionada pertenece a la columna `Código`.
- La columna `Cantidad` continúa siendo la única editable.
- Al confirmar una modificación de cantidad se actualiza el importe de la fila y se recalculan todos los totales.
- Los importes se recalculan desde la tabla después de agregar, editar o eliminar una partida, evitando acumuladores incrementales inconsistentes.

### Cálculo de IVA

El costo unitario ya incluye IVA.

Para artículos gravados:

```text
importeConIva = costoUnitario * cantidad
baseGravada = importeConIva / 1.16
iva = importeConIva - baseGravada
```

Para artículos exentos (`ArticuloByCodigo.exento == true`):

```text
subtotal = importeConIva
iva = 0
```

Se actualizan:

- `txfSubTotal`: suma de bases sin IVA más importes exentos.
- `txfIva`: IVA incluido correspondiente únicamente a partidas gravadas.
- `lblTotalCompra`: subtotal + IVA.

### `Fr_ListaArticulos`

- `ENTER` sobre una fila seleccionada ejecuta el mismo flujo que `btnSeleccionarArticulo`.
- Se conserva la solicitud de cantidad mediante `JOptionPane.showInputDialog(...)`.
- Cuando la consulta por código no devuelve el artículo seleccionado, se consulta su detalle por `id_articulo` para distinguir si está inactivo.
- Si el artículo está inactivo se muestra un `JOptionPane.showConfirmDialog` indicando que está dado de baja y preguntando si se desea habilitar nuevamente.
- Si el usuario selecciona `Sí`, se abre `Fr_DatosArticulo` en modo edición con el `idArticulo` y la sucursal actuales.
- Si el usuario cancela o selecciona `No`, no se agrega la partida ni se ejecuta otra operación.
- Al guardar correctamente desde `Fr_DatosArticulo`, el listado auxiliar se refresca para reflejar la reactivación.

## Archivos modificados

```text
src/main/java/com/kathsoft/kathpos/app/controller/CompraController.java
src/main/java/com/kathsoft/kathpos/app/view/compras/Fr_DatosCompras.java
src/main/java/com/kathsoft/kathpos/app/view/shared/Fr_ListaArticulos.java
```

## Fuera de alcance

- Persistencia definitiva de la compra.
- Conversión de las filas de la tabla a `ArticuloPorCompra`.
- Validaciones finales del formulario antes de guardar.
- Modificación de layouts o distribución visual.

## Nota técnica

`getSiguienteIdCompra(int idSucursal)` implementa exactamente la mecánica solicitada sobre el listado actual de compras. El ID definitivo continúa siendo responsabilidad del `AUTO_INCREMENT` de MySQL al efectuar el `INSERT`.

La reactivación del artículo reutiliza el flujo de edición existente de `Fr_DatosArticulo`; dicho formulario construye la actualización con `activo = true`, por lo que guardar la edición rehabilita el registro mediante el flujo ya existente.