### PR TITLE
test: validate purchase create and update procedures

### DIFF
--- a/.github/workflows/database-integration-tests.yml
+++ b/.github/workflows/database-integration-tests.yml
@@ -1,4 +1,4 @@
-name: Database integration tests
+name: Purchase database integration tests
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   verify:
-    name: Maven verify with MySQL 8
+    name: Validate purchase create and update flows
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -26,5 +26,5 @@ jobs:
           java-version: '21'
           cache: maven
 
-      - name: Run unit and integration tests
+      - name: Run stored procedure and controller validations
         run: ./mvnw --batch-mode --no-transfer-progress verify

--- a/database/README.md
+++ b/database/README.md
@@ -3,17 +3,28 @@
 Estos scripts describen la estructura de base de datos compatible con MySQL
 8.0.46. No contienen información de clientes ni datos operativos.
 
-El orden de ejecución es:
+Para las pruebas de integración de artículos y compras, el orden de ejecución
+es:
 
 1. `schema.sql`
-2. `procedures.sql`
+2. `procedures/procedures_articulos.sql`
+3. `procedures/procedures_compras.sql`
 
 Los scripts deben ejecutarse seleccionando previamente la base `kath_erp`:
 
 ```shell
 mysql -u <usuario> -p kath_erp < database/schema.sql
-mysql -u <usuario> -p kath_erp < database/procedures.sql
+mysql -u <usuario> -p kath_erp < database/procedures/procedures_articulos.sql
+mysql -u <usuario> -p kath_erp < database/procedures/procedures_compras.sql
 ```
+
+Cada procedimiento modular tiene un único archivo propietario. Los
+procedimientos que operan partidas de compra pertenecen a
+`procedures_compras.sql`, aunque también consulten o actualicen artículos.
+
+`procedures.sql` se conserva como el volcado general histórico. No debe
+ejecutarse junto con los scripts modulares porque contiene procedimientos con
+los mismos nombres.
 
 Los datos artificiales utilizados por las pruebas están separados en
 `src/test/resources/db/fixtures` y nunca deben instalarse en una base de datos

--- a/database/procedures/procedures_articulos.sql
+++ b/database/procedures/procedures_articulos.sql
@@ -1,125 +1,6 @@
-CREATE PROCEDURE `kath_erp`.`deleteArticuloCompra`(
-    IN p_id_detalle_compra INT UNSIGNED
-)
-    MODIFIES SQL DATA
-    COMMENT 'Elimina un artículo del detalle de compra y descuenta su existencia si es válido'
-BEGIN
-    DECLARE v_id_compra INT UNSIGNED DEFAULT 0;
-    DECLARE v_id_articulo INT UNSIGNED DEFAULT 0;
-    DECLARE v_cantidad_actual INT DEFAULT 0;
-    DECLARE v_existencia_actual INT DEFAULT 0;
-    DECLARE v_id_existencia INT DEFAULT 0;
-    DECLARE v_id_sucursal BIGINT UNSIGNED DEFAULT 0;
-    DECLARE v_fecha_compra DATE;
-    DECLARE v_ventas_posteriores INT DEFAULT 0;
-    DECLARE v_registros_existencia INT DEFAULT 0;
+SET NAMES utf8mb4;
 
-    DECLARE v_sqlstate CHAR(5);
-    DECLARE v_errno INT;
-    DECLARE v_text TEXT
-        CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
-
-    DECLARE EXIT HANDLER FOR SQLEXCEPTION
-    BEGIN
-        GET DIAGNOSTICS CONDITION 1
-            v_sqlstate = RETURNED_SQLSTATE,
-            v_errno = MYSQL_ERRNO,
-            v_text = MESSAGE_TEXT;
-
-        SELECT
-            500 AS id,
-            CONCAT('Error ', v_errno, ' (', v_sqlstate, '): ', v_text) AS message;
-    END;
-
-    IF p_id_detalle_compra IS NULL OR p_id_detalle_compra <= 0 THEN
-        SIGNAL SQLSTATE '45000'
-            SET MESSAGE_TEXT = 'El detalle de compra es obligatorio';
-    END IF;
-
-    SELECT
-        axc.id_compra,
-        axc.id_articulo,
-        axc.cantidad,
-        c.fecha_compra,
-        emp.id_sucursal
-    INTO
-        v_id_compra,
-        v_id_articulo,
-        v_cantidad_actual,
-        v_fecha_compra,
-        v_id_sucursal
-    FROM kath_erp.articulo_x_compra AS axc
-    INNER JOIN kath_erp.compras AS c
-        ON axc.id_compra = c.id_compra
-    INNER JOIN kath_erp.empleados AS emp
-        ON c.id_empleado = emp.id_empleado
-    WHERE axc.id = p_id_detalle_compra
-      AND c.activo = TRUE
-    LIMIT 1
-    FOR UPDATE;
-
-    IF v_id_compra IS NULL OR v_id_compra <= 0 THEN
-        SIGNAL SQLSTATE '45000'
-            SET MESSAGE_TEXT = 'El detalle de compra no existe o la compra está inactiva';
-    END IF;
-
-    SELECT COUNT(*)
-    INTO v_ventas_posteriores
-    FROM kath_erp.articulo_x_venta AS axv
-    INNER JOIN kath_erp.ventas AS v
-        ON axv.id_venta = v.id_venta
-    INNER JOIN kath_erp.empleados AS emp_venta
-        ON v.id_empleado = emp_venta.id_empleado
-    WHERE axv.id_articulo = v_id_articulo
-      AND emp_venta.id_sucursal = v_id_sucursal
-      AND v.fecha > v_fecha_compra
-      AND v.status_venta = TRUE;
-
-    IF v_ventas_posteriores > 0 THEN
-        SIGNAL SQLSTATE '45000'
-            SET MESSAGE_TEXT = 'No se puede eliminar el artículo porque ya tiene ventas posteriores a la compra';
-    END IF;
-
-    SELECT COUNT(*)
-    INTO v_registros_existencia
-    FROM kath_erp.existencia_x_sucursal
-    WHERE id_articulo = v_id_articulo
-      AND id_sucursal = v_id_sucursal;
-
-    IF v_registros_existencia = 0 THEN
-        SIGNAL SQLSTATE '45000'
-            SET MESSAGE_TEXT = 'No existe registro de existencia para el artículo y sucursal';
-    END IF;
-
-    IF v_registros_existencia > 1 THEN
-        SIGNAL SQLSTATE '45000'
-            SET MESSAGE_TEXT = 'Existe más de un registro de existencia para el artículo y sucursal';
-    END IF;
-
-    SELECT id, COALESCE(existencia, 0)
-    INTO v_id_existencia, v_existencia_actual
-    FROM kath_erp.existencia_x_sucursal
-    WHERE id_articulo = v_id_articulo
-      AND id_sucursal = v_id_sucursal
-    LIMIT 1
-    FOR UPDATE;
-
-    IF v_existencia_actual - v_cantidad_actual < 0 THEN
-        SIGNAL SQLSTATE '45000'
-            SET MESSAGE_TEXT = 'No se puede eliminar el artículo porque la existencia quedaría negativa';
-    END IF;
-
-    DELETE FROM kath_erp.articulo_x_compra
-    WHERE id = p_id_detalle_compra;
-
-    UPDATE kath_erp.existencia_x_sucursal
-    SET existencia = v_existencia_actual - v_cantidad_actual
-    WHERE id = v_id_existencia;
-
-    SELECT
-        p_id_detalle_compra AS id,
-        'Artículo eliminado de la compra correctamente' AS message;
-END;
+DELIMITER $$
 
 CREATE PROCEDURE `kath_erp`.`eliminar_articulo`(
 	IN id INT
@@ -136,7 +17,7 @@ BEGIN
 		activo = 0
 	WHERE articulo.id_articulo = id;
     
-END;
+END $$
 
 CREATE PROCEDURE `kath_erp`.`getArticuloByCodigo`(
 	IN codigo_a VARCHAR(65) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
@@ -172,7 +53,7 @@ BEGIN
     	AND exs.id_sucursal = `idSucursal`
     	AND pxt.id_tipoCliente = `idTipoCliente`;
     
-END;
+END $$
 
 CREATE PROCEDURE `kath_erp`.`getArticuloById`(
 	IN p_id_articulo INT UNSIGNED
@@ -201,7 +82,7 @@ BEGIN
 	FROM kath_erp.articulo AS art	
 	WHERE art.id_articulo = p_id_articulo;
 	
-END;
+END $$
 
 CREATE PROCEDURE `kath_erp`.`insertArticulo`(
 	IN p_id_proveedor INT UNSIGNED,
@@ -326,110 +207,7 @@ BEGIN
 		'Articulo registrado correctamente' AS message;
 
 	
-END;
-
-CREATE PROCEDURE `kath_erp`.`insertArticuloCompra`(
-    IN p_id_compra INT UNSIGNED,
-    IN p_id_articulo INT UNSIGNED,
-    IN p_cantidad INT,
-    IN p_subtotal DOUBLE
-)
-    MODIFIES SQL DATA
-    COMMENT 'Inserta un artículo en el detalle de compra. La existencia se actualiza con otro SP'
-BEGIN
-    DECLARE v_existe_compra INT DEFAULT 0;
-    DECLARE v_existe_articulo INT DEFAULT 0;
-    DECLARE v_existe_detalle INT DEFAULT 0;
-    DECLARE v_id_detalle INT UNSIGNED DEFAULT 0;
-
-    DECLARE v_sqlstate CHAR(5);
-    DECLARE v_errno INT;
-    DECLARE v_text TEXT
-        CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
-
-    DECLARE EXIT HANDLER FOR SQLEXCEPTION
-    BEGIN
-        GET DIAGNOSTICS CONDITION 1
-            v_sqlstate = RETURNED_SQLSTATE,
-            v_errno = MYSQL_ERRNO,
-            v_text = MESSAGE_TEXT;
-
-        SELECT
-            500 AS id,
-            CONCAT('Error ', v_errno, ' (', v_sqlstate, '): ', v_text) AS message;
-    END;
-
-    IF p_id_compra IS NULL OR p_id_compra <= 0 THEN
-        SIGNAL SQLSTATE '45000'
-            SET MESSAGE_TEXT = 'La compra es obligatoria';
-    END IF;
-
-    IF p_id_articulo IS NULL OR p_id_articulo <= 0 THEN
-        SIGNAL SQLSTATE '45000'
-            SET MESSAGE_TEXT = 'El artículo es obligatorio';
-    END IF;
-
-    IF p_cantidad IS NULL OR p_cantidad <= 0 THEN
-        SIGNAL SQLSTATE '45000'
-            SET MESSAGE_TEXT = 'La cantidad debe ser mayor a cero';
-    END IF;
-
-    IF p_subtotal IS NULL OR p_subtotal < 0 THEN
-        SIGNAL SQLSTATE '45000'
-            SET MESSAGE_TEXT = 'El subtotal del artículo no puede ser negativo';
-    END IF;
-
-    SELECT COUNT(*)
-    INTO v_existe_compra
-    FROM kath_erp.compras
-    WHERE id_compra = p_id_compra
-      AND activo = TRUE;
-
-    IF v_existe_compra = 0 THEN
-        SIGNAL SQLSTATE '45000'
-            SET MESSAGE_TEXT = 'La compra indicada no existe o está inactiva';
-    END IF;
-
-    SELECT COUNT(*)
-    INTO v_existe_articulo
-    FROM kath_erp.articulo
-    WHERE id_articulo = p_id_articulo
-      AND activo = TRUE;
-
-    IF v_existe_articulo = 0 THEN
-        SIGNAL SQLSTATE '45000'
-            SET MESSAGE_TEXT = 'El artículo indicado no existe o está inactivo';
-    END IF;
-
-    SELECT COUNT(*)
-    INTO v_existe_detalle
-    FROM kath_erp.articulo_x_compra
-    WHERE id_compra = p_id_compra
-      AND id_articulo = p_id_articulo;
-
-    IF v_existe_detalle > 0 THEN
-        SIGNAL SQLSTATE '45000'
-            SET MESSAGE_TEXT = 'El artículo ya está registrado en esta compra';
-    END IF;
-
-    INSERT INTO kath_erp.articulo_x_compra (
-        id_compra,
-        id_articulo,
-        cantidad,
-        subtotal
-    ) VALUES (
-        p_id_compra,
-        p_id_articulo,
-        p_cantidad,
-        p_subtotal
-    );
-
-    SET v_id_detalle = LAST_INSERT_ID();
-
-    SELECT
-        v_id_detalle AS id,
-        'Artículo agregado a la compra correctamente' AS message;
-END;
+END $$
 
 CREATE PROCEDURE `kath_erp`.`insertExistenciaArticuloSucursal`(
 	IN p_id_articulo INT UNSIGNED,
@@ -502,7 +280,7 @@ BEGIN
 	SELECT
 		LAST_INSERT_ID() AS id,
 		'Existencia registrada correctamente' AS message;
-END;
+END $$
 
 CREATE PROCEDURE `kath_erp`.`insertPrecioArticuloTipoCliente`(
 	IN p_id_articulo INT UNSIGNED,
@@ -602,7 +380,7 @@ BEGIN
 	SELECT
 		LAST_INSERT_ID() AS id,
 		'Precio registrado correctamente' AS message;
-END;
+END $$
 
 CREATE PROCEDURE `kath_erp`.`listArticulos`(
 	IN p_id_sucursal BIGINT UNSIGNED,
@@ -704,33 +482,7 @@ BEGIN
 		CASE WHEN v_ordenar_por = 'CATEGORIA' THEN cat.nombre END ASC,
 		art.nombre ASC;
     
-END;
-
-CREATE PROCEDURE `kath_erp`.`listArticulosCompraById`(
-    IN p_id_compra INT UNSIGNED
-)
-    READS SQL DATA
-    COMMENT 'Lista los artículos registrados en una compra'
-BEGIN
-    IF p_id_compra IS NULL OR p_id_compra <= 0 THEN
-        SIGNAL SQLSTATE '45000'
-            SET MESSAGE_TEXT = 'La compra es obligatoria';
-    END IF;
-
-    SELECT
-        axc.id,
-        axc.id_compra,
-        axc.id_articulo,
-        a.codigo_articulo,
-        a.nombre AS nombre_articulo,
-        axc.cantidad,
-        axc.subtotal
-    FROM kath_erp.articulo_x_compra AS axc
-    INNER JOIN kath_erp.articulo AS a
-        ON axc.id_articulo = a.id_articulo
-    WHERE axc.id_compra = p_id_compra
-    ORDER BY axc.id ASC;
-END;
+END $$
 
 CREATE PROCEDURE `kath_erp`.`listExistenciaGlobalArticulo`(
 	IN p_id_articulo INT UNSIGNED
@@ -748,7 +500,7 @@ BEGIN
 	INNER JOIN kath_erp.sucursal AS s on exs.id_sucursal = s.id_sucursar 
 	WHERE exs.id_articulo = p_id_articulo;
 		
-END;
+END $$
 
 CREATE PROCEDURE `kath_erp`.`listPreciosArticuloTipoCliente`(
     IN p_id_articulo INT UNSIGNED
@@ -769,7 +521,7 @@ BEGIN
       AND tc.activo = 1
     ORDER BY tc.nombre ASC;
 
-END;
+END $$
 
 CREATE PROCEDURE `kath_erp`.`updateArticulo`(
 	IN p_id_articulo INT UNSIGNED,
@@ -831,216 +583,7 @@ BEGIN
 
     END IF;
     
-END;
-
-CREATE PROCEDURE `kath_erp`.`updateArticuloCompra`(
-    IN p_id_detalle_compra INT UNSIGNED,
-    IN p_cantidad INT,
-    IN p_subtotal DOUBLE
-)
-    MODIFIES SQL DATA
-    COMMENT 'Actualiza un artículo comprado y ajusta existencia en la sucursal registrada en la compra'
-BEGIN
-    DECLARE v_id_compra INT UNSIGNED DEFAULT 0;
-    DECLARE v_id_articulo INT UNSIGNED DEFAULT 0;
-    DECLARE v_cantidad_actual INT DEFAULT 0;
-
-    DECLARE v_delta INT DEFAULT 0;
-
-    DECLARE v_existencia_actual INT DEFAULT 0;
-    DECLARE v_id_existencia INT DEFAULT 0;
-
-    DECLARE v_id_sucursal BIGINT UNSIGNED DEFAULT 0;
-
-    DECLARE v_fecha_compra DATE;
-
-    DECLARE v_ventas_posteriores INT DEFAULT 0;
-    DECLARE v_registros_existencia INT DEFAULT 0;
-
-    DECLARE v_sqlstate CHAR(5);
-    DECLARE v_errno INT;
-    DECLARE v_text TEXT
-        CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
-
-
-    DECLARE EXIT HANDLER FOR SQLEXCEPTION
-    BEGIN
-        GET DIAGNOSTICS CONDITION 1
-            v_sqlstate = RETURNED_SQLSTATE,
-            v_errno = MYSQL_ERRNO,
-            v_text = MESSAGE_TEXT;
-
-        SELECT
-            500 AS id,
-            CONCAT(
-                'Error ',
-                v_errno,
-                ' (',
-                v_sqlstate,
-                '): ',
-                v_text
-            ) AS message;
-    END;
-
-
-    IF p_id_detalle_compra IS NULL
-       OR p_id_detalle_compra <= 0 THEN
-
-        SIGNAL SQLSTATE '45000'
-            SET MESSAGE_TEXT = 'El detalle de compra es obligatorio';
-
-    END IF;
-
-
-    IF p_cantidad IS NULL OR p_cantidad <= 0 THEN
-
-        SIGNAL SQLSTATE '45000'
-            SET MESSAGE_TEXT = 'La cantidad debe ser mayor a cero';
-
-    END IF;
-
-
-    IF p_subtotal IS NULL OR p_subtotal < 0 THEN
-
-        SIGNAL SQLSTATE '45000'
-            SET MESSAGE_TEXT = 'El subtotal no puede ser negativo';
-
-    END IF;
-
-
-    /*
-     * Se obtiene directamente c.id_sucursal.
-     * Ya no necesitamos JOIN empleados.
-     */
-
-    SELECT
-        axc.id_compra,
-        axc.id_articulo,
-        axc.cantidad,
-        c.fecha_compra,
-        c.id_sucursal
-    INTO
-        v_id_compra,
-        v_id_articulo,
-        v_cantidad_actual,
-        v_fecha_compra,
-        v_id_sucursal
-    FROM kath_erp.articulo_x_compra AS axc
-    INNER JOIN kath_erp.compras AS c
-        ON axc.id_compra = c.id_compra
-    WHERE axc.id = p_id_detalle_compra
-      AND c.activo = TRUE
-    LIMIT 1
-    FOR UPDATE;
-
-
-    IF v_id_compra IS NULL OR v_id_compra <= 0 THEN
-
-        SIGNAL SQLSTATE '45000'
-            SET MESSAGE_TEXT =
-                'El detalle de compra no existe o la compra está inactiva';
-
-    END IF;
-
-
-    /*
-     * Esta parte sigue dependiendo de cómo ventas determina su sucursal.
-     *
-     * Por ahora se mantiene porque no me compartiste una relación directa
-     * ventas -> sucursal.
-     */
-
-    SELECT COUNT(*)
-    INTO v_ventas_posteriores
-    FROM kath_erp.articulo_x_venta AS axv
-    INNER JOIN kath_erp.ventas AS v
-        ON axv.id_venta = v.id_venta
-    INNER JOIN kath_erp.empleados AS emp_venta
-        ON v.id_empleado = emp_venta.id_empleado
-    WHERE axv.id_articulo = v_id_articulo
-      AND emp_venta.id_sucursal = v_id_sucursal
-      AND v.fecha > v_fecha_compra
-      AND v.status_venta = TRUE;
-
-
-    IF v_ventas_posteriores > 0 THEN
-
-        SIGNAL SQLSTATE '45000'
-            SET MESSAGE_TEXT =
-                'No se puede modificar el artículo porque ya tiene ventas posteriores a la compra';
-
-    END IF;
-
-
-    SELECT COUNT(*)
-    INTO v_registros_existencia
-    FROM kath_erp.existencia_x_sucursal
-    WHERE id_articulo = v_id_articulo
-      AND id_sucursal = v_id_sucursal;
-
-
-    IF v_registros_existencia = 0 THEN
-
-        SIGNAL SQLSTATE '45000'
-            SET MESSAGE_TEXT =
-                'No existe registro de existencia para el artículo y sucursal';
-
-    END IF;
-
-
-    IF v_registros_existencia > 1 THEN
-
-        SIGNAL SQLSTATE '45000'
-            SET MESSAGE_TEXT =
-                'Existe más de un registro de existencia para el artículo y sucursal';
-
-    END IF;
-
-
-    SELECT
-        id,
-        COALESCE(existencia, 0)
-    INTO
-        v_id_existencia,
-        v_existencia_actual
-    FROM kath_erp.existencia_x_sucursal
-    WHERE id_articulo = v_id_articulo
-      AND id_sucursal = v_id_sucursal
-    LIMIT 1
-    FOR UPDATE;
-
-
-    SET v_delta =
-        p_cantidad - v_cantidad_actual;
-
-
-    IF v_existencia_actual + v_delta < 0 THEN
-
-        SIGNAL SQLSTATE '45000'
-            SET MESSAGE_TEXT =
-                'No se puede modificar la compra porque la existencia quedaría negativa';
-
-    END IF;
-
-
-    UPDATE kath_erp.articulo_x_compra
-    SET
-        cantidad = p_cantidad,
-        subtotal = p_subtotal
-    WHERE id = p_id_detalle_compra;
-
-
-    UPDATE kath_erp.existencia_x_sucursal
-    SET existencia =
-        v_existencia_actual + v_delta
-    WHERE id = v_id_existencia;
-
-
-    SELECT
-        p_id_detalle_compra AS id,
-        'Artículo de compra actualizado correctamente' AS message;
-
-END;
+END $$
 
 CREATE PROCEDURE `kath_erp`.`ver_articulos`(
 	IN `id_sucursal` INT,
@@ -1068,7 +611,7 @@ WHERE existencia_x_sucursal.id_sucursal = id_sucursal
   AND precios_x_tipoCliente.id_tipoCliente = id_tipoCliente_a
 ORDER BY id_articulo;
 
-END;
+END $$
 
 CREATE PROCEDURE `kath_erp`.`ver_codigos_articulos`()
 BEGIN
@@ -1076,4 +619,6 @@ BEGIN
     SELECT articulo.codigo_articulo
     FROM articulo;
     
-END;
+END $$
+
+DELIMITER ;

--- a/database/procedures/procedures_compras.sql
+++ b/database/procedures/procedures_compras.sql
@@ -1,3 +1,7 @@
+SET NAMES utf8mb4;
+
+DELIMITER $$
+
 CREATE  PROCEDURE `kath_erp`.`deleteArticuloCompra`(
     IN p_id_detalle_compra INT UNSIGNED
 )
@@ -119,7 +123,7 @@ BEGIN
     SELECT
         p_id_detalle_compra AS id,
         'Artículo eliminado de la compra correctamente' AS message;
-END;
+END $$
 
 CREATE  PROCEDURE `kath_erp`.`getCompraById`(
     IN p_id_compra INT UNSIGNED
@@ -156,7 +160,7 @@ BEGIN
         ON c.id_empleado = emp.id_empleado
     WHERE c.id_compra = p_id_compra
     LIMIT 1;
-END;
+END $$
 
 CREATE  PROCEDURE `kath_erp`.`getIdUltimaCompra`()
     READS SQL DATA
@@ -170,7 +174,7 @@ BEGIN
 	ORDER BY
 		c.id_compra DESC LIMIT 1;
 	
-END;
+END $$
 
 CREATE  PROCEDURE `kath_erp`.`insertArticuloCompra`(
     IN p_id_compra INT UNSIGNED,
@@ -273,7 +277,7 @@ BEGIN
     SELECT
         v_id_detalle AS id,
         'Artículo agregado a la compra correctamente' AS message;
-END;
+END $$
 
 CREATE  PROCEDURE `kath_erp`.`insertCompra`(
     IN p_id_empleado INT UNSIGNED,
@@ -463,7 +467,7 @@ BEGIN
         v_id_compra AS id,
         'Compra registrada correctamente' AS message;
 
-END;
+END $$
 
 CREATE  PROCEDURE `kath_erp`.`listArticulosCompraById`(
     IN p_id_compra INT UNSIGNED
@@ -489,7 +493,7 @@ BEGIN
         ON axc.id_articulo = a.id_articulo
     WHERE axc.id_compra = p_id_compra
     ORDER BY axc.id ASC;
-END;
+END $$
 
 CREATE  PROCEDURE `kath_erp`.`listCompras`(
     IN p_id_sucursal BIGINT UNSIGNED,
@@ -562,7 +566,7 @@ BEGIN
         c.fecha_compra DESC,
         c.id_compra DESC;
 
-END;
+END $$
 
 CREATE  PROCEDURE `kath_erp`.`sumarExistenciaSucursalCompra`(
     IN p_id_compra INT UNSIGNED,
@@ -684,7 +688,7 @@ BEGIN
         200 AS id,
         'Existencia actualizada correctamente' AS message;
 
-END;
+END $$
 
 CREATE  PROCEDURE `kath_erp`.`updateArticuloCompra`(
     IN p_id_detalle_compra INT UNSIGNED,
@@ -893,7 +897,7 @@ BEGIN
         p_id_detalle_compra AS id,
         'Artículo de compra actualizado correctamente' AS message;
 
-END;
+END $$
 
 CREATE  PROCEDURE `kath_erp`.`updateCompra`(
     IN p_id_compra INT UNSIGNED,
@@ -1168,4 +1172,6 @@ BEGIN
         p_id_compra AS id,
         'Compra actualizada correctamente' AS message;
 
-END;
+END $$
+
+DELIMITER ;

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,8 @@
         <targetPath>db/init</targetPath>
         <includes>
           <include>schema.sql</include>
-          <include>procedures.sql</include>
+          <include>procedures/procedures_articulos.sql</include>
+          <include>procedures/procedures_compras.sql</include>
         </includes>
       </testResource>
     </testResources>

--- a/src/main/java/com/kathsoft/kathpos/app/controller/CompraController.java
+++ b/src/main/java/com/kathsoft/kathpos/app/controller/CompraController.java
@@ -290,6 +290,10 @@ public class CompraController implements java.io.Serializable {
 				}
 
 				for (ArticuloPorCompra articuloPorCompra : articulos) {
+					if (articuloPorCompra.getId() <= 0) {
+						articuloPorCompra.setIdCompra(compraConDetalle.getCompra().getIdCompra());
+					}
+
 					SpResponseModel respuestaDetalle = articuloPorCompra.getId() > 0
 							? this.updateArticuloCompra(connection, articuloPorCompra)
 							: this.insertArticuloCompra(connection, articuloPorCompra);

--- a/src/test/java/com/kathsoft/kathpos/integration/CompraControllerIT.java
+++ b/src/test/java/com/kathsoft/kathpos/integration/CompraControllerIT.java
@@ -48,11 +48,14 @@ class CompraControllerIT {
                     MountableFile.forClasspathResource("db/init/schema.sql"),
                     "/docker-entrypoint-initdb.d/01-schema.sql")
             .withCopyFileToContainer(
-                    MountableFile.forClasspathResource("db/init/procedures.sql"),
-                    "/docker-entrypoint-initdb.d/02-procedures.sql")
+                    MountableFile.forClasspathResource("db/init/procedures/procedures_articulos.sql"),
+                    "/docker-entrypoint-initdb.d/02-procedures-articulos.sql")
+            .withCopyFileToContainer(
+                    MountableFile.forClasspathResource("db/init/procedures/procedures_compras.sql"),
+                    "/docker-entrypoint-initdb.d/03-procedures-compras.sql")
             .withCopyFileToContainer(
                     MountableFile.forClasspathResource("db/fixtures/compra_minima.sql"),
-                    "/docker-entrypoint-initdb.d/03-compra-minima.sql");
+                    "/docker-entrypoint-initdb.d/04-compra-minima.sql");
 
     @BeforeAll
     static void configurarConexionDelControlador() {
@@ -157,6 +160,138 @@ class CompraControllerIT {
                 () -> assertEquals(40, consultarExistencia(ID_ARTICULO_EXISTENTE, ID_SUCURSAL_CONTROL)));
     }
 
+    @Test
+    void editaCabeceraPartidaExistenteYAgregaUnaPartidaNueva() throws SQLException {
+        CompraController controller = new CompraController();
+        int idCompra = registrarCompraInicial(controller, "FAC-EDIT-001");
+        int idDetalleExistente = consultarIdDetalle(idCompra, ID_ARTICULO_EXISTENTE);
+
+        ArticuloPorCompra detalleActualizado = new ArticuloPorCompra.ArticuloPorCompraBuilder()
+                .id(idDetalleExistente)
+                .idCompra(idCompra)
+                .idArticulo(ID_ARTICULO_EXISTENTE)
+                .cantidad(1)
+                .subtotal(100.00)
+                .build();
+        ArticuloPorCompra detalleNuevo = crearDetalle(ID_ARTICULO_NUEVO, 3, 150.00);
+        CompraConDetalle compraEditada = new CompraConDetalle(
+                crearCompraEditada(idCompra, "FAC-EDIT-002", 250.00, 40.00),
+                List.of(detalleActualizado, detalleNuevo));
+
+        SpResponseModel respuesta = controller.updateCompra(ID_SUCURSAL_COMPRA, compraEditada);
+
+        assertAll(
+                () -> assertEquals(idCompra, respuesta.id(), respuesta.message()),
+                () -> assertEquals("Compra actualizada correctamente", respuesta.message()),
+                () -> assertEquals(idCompra, detalleNuevo.getIdCompra()));
+
+        CompraById compraConsultada = controller.getCompraById(idCompra);
+        assertNotNull(compraConsultada);
+        assertAll(
+                () -> assertEquals("FAC-EDIT-002", compraConsultada.getFolioFactura()),
+                () -> assertTrue(compraConsultada.isTipoCompra()),
+                () -> assertEquals(250.00, compraConsultada.getSubtotal(), 0.001),
+                () -> assertEquals(40.00, compraConsultada.getIva(), 0.001),
+                () -> assertEquals(290.00, compraConsultada.getImporteTotal(), 0.001));
+
+        assertAll(
+                () -> assertEquals(2, consultarEntero(
+                        "SELECT COUNT(*) FROM articulo_x_compra WHERE id_compra = ?", idCompra)),
+                () -> assertEquals(1, consultarEntero(
+                        "SELECT cantidad FROM articulo_x_compra WHERE id_compra = ? AND id_articulo = ?",
+                        idCompra, ID_ARTICULO_EXISTENTE)),
+                () -> assertEquals(3, consultarEntero(
+                        "SELECT cantidad FROM articulo_x_compra WHERE id_compra = ? AND id_articulo = ?",
+                        idCompra, ID_ARTICULO_NUEVO)),
+                () -> assertEquals(250.00, consultarDouble(
+                        "SELECT SUM(subtotal) FROM articulo_x_compra WHERE id_compra = ?", idCompra), 0.001));
+
+        assertAll(
+                () -> assertEquals(6, consultarExistencia(ID_ARTICULO_EXISTENTE, ID_SUCURSAL_COMPRA)),
+                () -> assertEquals(3, consultarExistencia(ID_ARTICULO_NUEVO, ID_SUCURSAL_COMPRA)),
+                () -> assertEquals(40, consultarExistencia(ID_ARTICULO_EXISTENTE, ID_SUCURSAL_CONTROL)),
+                () -> assertEquals(25, consultarExistencia(ID_ARTICULO_NUEVO, ID_SUCURSAL_CONTROL)));
+    }
+
+    @Test
+    void revierteLaEdicionCompletaCuandoFallaUnaPartidaNueva() throws SQLException {
+        CompraController controller = new CompraController();
+        int idCompra = registrarCompraInicial(controller, "FAC-EDIT-003");
+        int idDetalleExistente = consultarIdDetalle(idCompra, ID_ARTICULO_EXISTENTE);
+
+        ArticuloPorCompra detalleActualizado = new ArticuloPorCompra.ArticuloPorCompraBuilder()
+                .id(idDetalleExistente)
+                .idCompra(idCompra)
+                .idArticulo(ID_ARTICULO_EXISTENTE)
+                .cantidad(4)
+                .subtotal(400.00)
+                .build();
+        CompraConDetalle compraEditada = new CompraConDetalle(
+                crearCompraEditada(idCompra, "FAC-EDIT-004", 500.00, 80.00),
+                List.of(detalleActualizado, crearDetalle(999_999, 1, 100.00)));
+
+        SpResponseModel respuesta = controller.updateCompra(ID_SUCURSAL_COMPRA, compraEditada);
+
+        assertAll(
+                () -> assertEquals(500, respuesta.id()),
+                () -> assertTrue(respuesta.message().contains("no existe o está inactivo")));
+
+        CompraById compraConsultada = controller.getCompraById(idCompra);
+        assertNotNull(compraConsultada);
+        assertAll(
+                () -> assertEquals("FAC-EDIT-003", compraConsultada.getFolioFactura()),
+                () -> assertEquals(200.00, compraConsultada.getSubtotal(), 0.001),
+                () -> assertEquals(32.00, compraConsultada.getIva(), 0.001),
+                () -> assertEquals(2, consultarEntero(
+                        "SELECT cantidad FROM articulo_x_compra WHERE id = ?", idDetalleExistente)),
+                () -> assertEquals(1, consultarEntero(
+                        "SELECT COUNT(*) FROM articulo_x_compra WHERE id_compra = ?", idCompra)),
+                () -> assertEquals(7, consultarExistencia(ID_ARTICULO_EXISTENTE, ID_SUCURSAL_COMPRA)));
+    }
+
+    @Test
+    void rechazaEditarUnaCompraDesdeOtraSucursal() throws SQLException {
+        CompraController controller = new CompraController();
+        int idCompra = registrarCompraInicial(controller, "FAC-EDIT-005");
+        CompraConDetalle compraEditada = new CompraConDetalle(
+                crearCompraEditada(idCompra, "FAC-EDIT-006", 200.00, 32.00),
+                List.of());
+
+        SpResponseModel respuesta = controller.updateCompra(ID_SUCURSAL_CONTROL, compraEditada);
+
+        assertAll(
+                () -> assertEquals(500, respuesta.id()),
+                () -> assertTrue(respuesta.message().contains("no pertenece a la sucursal actual")),
+                () -> assertEquals(1, consultarEntero(
+                        "SELECT COUNT(*) FROM compras WHERE id_compra = ? AND folio_factura = ? AND id_sucursal = ?",
+                        idCompra, "FAC-EDIT-005", ID_SUCURSAL_COMPRA)),
+                () -> assertEquals(7, consultarExistencia(ID_ARTICULO_EXISTENTE, ID_SUCURSAL_COMPRA)));
+    }
+
+    private int registrarCompraInicial(CompraController controller, String folio) {
+        SpResponseModel respuesta = controller.insertCompra(
+                ID_SUCURSAL_COMPRA,
+                new CompraConDetalle(
+                        crearCompra(folio, 200.00, 32.00),
+                        List.of(crearDetalle(ID_ARTICULO_EXISTENTE, 2, 200.00))));
+        assertTrue(respuesta.id() > 0, respuesta.message());
+        return respuesta.id();
+    }
+
+    private Compra crearCompraEditada(int idCompra, String folio, double subtotal, double iva) {
+        return new Compra.CompraBuilder()
+                .idCompra(idCompra)
+                .idEmpleado(1)
+                .idProveedor(1)
+                .folioFactura(folio)
+                .fechaFactura(Date.valueOf("2026-08-22"))
+                .fechaCompra(Date.valueOf("2026-08-23"))
+                .tipoCompra(true)
+                .subtotal(subtotal)
+                .iva(iva)
+                .build();
+    }
+
     private Compra crearCompra(String folio, double subtotal, double iva) {
         return new Compra.CompraBuilder()
                 .idEmpleado(1)
@@ -186,6 +321,12 @@ class CompraControllerIT {
         return consultarEntero(
                 "SELECT existencia FROM existencia_x_sucursal WHERE id_articulo = ? AND id_sucursal = ?",
                 idArticulo, idSucursal);
+    }
+
+    private int consultarIdDetalle(int idCompra, int idArticulo) throws SQLException {
+        return consultarEntero(
+                "SELECT id FROM articulo_x_compra WHERE id_compra = ? AND id_articulo = ?",
+                idCompra, idArticulo);
     }
 
     private int consultarEntero(String sql, Object... parametros) throws SQLException {

--- a/src/test/java/com/kathsoft/kathpos/integration/CompraStoredProcedureIT.java
+++ b/src/test/java/com/kathsoft/kathpos/integration/CompraStoredProcedureIT.java
@@ -40,11 +40,14 @@ class CompraStoredProcedureIT {
                     MountableFile.forClasspathResource("db/init/schema.sql"),
                     "/docker-entrypoint-initdb.d/01-schema.sql")
             .withCopyFileToContainer(
-                    MountableFile.forClasspathResource("db/init/procedures.sql"),
-                    "/docker-entrypoint-initdb.d/02-procedures.sql")
+                    MountableFile.forClasspathResource("db/init/procedures/procedures_articulos.sql"),
+                    "/docker-entrypoint-initdb.d/02-procedures-articulos.sql")
+            .withCopyFileToContainer(
+                    MountableFile.forClasspathResource("db/init/procedures/procedures_compras.sql"),
+                    "/docker-entrypoint-initdb.d/03-procedures-compras.sql")
             .withCopyFileToContainer(
                     MountableFile.forClasspathResource("db/fixtures/compra_minima.sql"),
-                    "/docker-entrypoint-initdb.d/03-compra-minima.sql");
+                    "/docker-entrypoint-initdb.d/04-compra-minima.sql");
 
     @BeforeEach
     void limpiarOperacionesDeCompra() throws SQLException {
@@ -56,13 +59,21 @@ class CompraStoredProcedureIT {
     }
 
     @Test
-    void cargaLosProcedimientosVigentesDeCompra() throws SQLException {
+    void cargaLosProcedimientosModularesDeArticulosYCompras() throws SQLException {
         Set<String> esperados = Set.of(
+                "deleteArticuloCompra",
+                "getArticuloById",
+                "getIdUltimaCompra",
                 "insertCompra",
                 "insertArticuloCompra",
+                "insertArticulo",
                 "sumarExistenciaSucursalCompra",
                 "listCompras",
-                "getCompraById");
+                "listArticulosCompraById",
+                "getCompraById",
+                "updateArticulo",
+                "updateArticuloCompra",
+                "updateCompra");
 
         Set<String> encontrados = new HashSet<>();
         String sql = """
@@ -70,15 +81,10 @@ class CompraStoredProcedureIT {
                 FROM information_schema.ROUTINES
                 WHERE ROUTINE_SCHEMA = ?
                   AND ROUTINE_TYPE = 'PROCEDURE'
-                  AND ROUTINE_NAME IN (?, ?, ?, ?, ?)
                 """;
 
         try (Connection connection = nuevaConexion(); PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, DATABASE_NAME);
-            int index = 2;
-            for (String nombre : esperados) {
-                statement.setString(index++, nombre);
-            }
 
             try (ResultSet resultSet = statement.executeQuery()) {
                 while (resultSet.next()) {
@@ -87,7 +93,11 @@ class CompraStoredProcedureIT {
             }
         }
 
-        assertEquals(esperados, encontrados);
+        assertTrue(encontrados.containsAll(esperados),
+                () -> "Faltan procedimientos: " + esperados.stream()
+                        .filter(nombre -> !encontrados.contains(nombre))
+                        .sorted()
+                        .toList());
     }
 
     @Test


### PR DESCRIPTION
## Resumen

- carga `procedures_articulos.sql` y `procedures_compras.sql` en una instancia limpia de MySQL 8
- agrega delimitadores válidos para ejecutar directamente los scripts modulares
- elimina declaraciones duplicadas y asigna los procedimientos de partidas al módulo de compras
- corrige la asignación de `idCompra` al agregar partidas nuevas durante una edición
- amplía las pruebas de integración para registrar y editar compras

## Validaciones de registro

- cabecera, detalles, subtotal, IVA e importe total
- incremento de existencia previa y creación de existencia nueva
- aislamiento de existencias entre sucursales
- rollback completo cuando una partida es inválida
- rechazo de folio duplicado

## Validaciones de edición

- actualización de cabecera
- ajuste de existencia por diferencia de cantidades
- incorporación de una partida nueva
- rollback de cabecera, detalles y existencias cuando falla una partida
- rechazo de edición desde otra sucursal

## GitHub Actions

El workflow `Purchase database integration tests` ejecuta:

```shell
./mvnw --batch-mode --no-transfer-progress verify
```

La PR permanece en draft hasta confirmar el resultado de MySQL 8 y Testcontainers.