### PR TITLE
feat(compras): integra flujo completo para registrar nuevas compras

### DIFF
--- a/src/main/java/com/kathsoft/kathpos/app/controller/CompraController.java
+++ b/src/main/java/com/kathsoft/kathpos/app/controller/CompraController.java
@@ -7,7 +7,9 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import com.kathsoft.kathpos.app.model.compra.ArticuloCompraListado;
 import com.kathsoft.kathpos.app.model.compra.ArticuloPorCompra;
@@ -22,6 +24,8 @@ import com.kathsoft.kathpos.tools.Conexion;
 public class CompraController implements java.io.Serializable {
 
 	private static final long serialVersionUID = -4974480297011718553L;
+	private static final int ERROR_VALIDACION = 500;
+	private static final double TOLERANCIA_IMPORTE = 0.01;
 	private static Connection cn = null;
 
 	public List<CompraListado> listCompras(int idSucursal) {
@@ -150,20 +154,26 @@ public class CompraController implements java.io.Serializable {
 	}
 
 	public SpResponseModel insertCompra(int idSucursal, Compra compra) {
+		SpResponseModel validacion = this.validarCabeceraNuevaCompra(idSucursal, compra);
+		if (validacion != null) {
+			return validacion;
+		}
+
 		try (Connection connection = Conexion.establecerConexionLocal(Conexion.DATA_BASE)) {
 			return this.insertCompra(connection, idSucursal, compra);
 		} catch (SQLException er) {
 			er.printStackTrace();
-			return new SpResponseModel(500, er.getMessage());
+			return new SpResponseModel(ERROR_VALIDACION, er.getMessage());
 		} catch (Exception er) {
 			er.printStackTrace();
-			return new SpResponseModel(500, er.getMessage());
+			return new SpResponseModel(ERROR_VALIDACION, er.getMessage());
 		}
 	}
 
 	public SpResponseModel insertCompra(int idSucursal, CompraConDetalle compraConDetalle) {
-		if (compraConDetalle == null || compraConDetalle.getCompra() == null) {
-			return new SpResponseModel(500, "La compra es obligatoria");
+		SpResponseModel validacion = this.validarNuevaCompra(idSucursal, compraConDetalle);
+		if (validacion != null) {
+			return validacion;
 		}
 
 		List<ArticuloPorCompra> articulos = compraConDetalle.getArticulosPorCompra() == null ? Collections.emptyList()
@@ -204,20 +214,20 @@ public class CompraController implements java.io.Serializable {
 			} catch (SQLException er) {
 				connection.rollback();
 				er.printStackTrace();
-				return new SpResponseModel(500, er.getMessage());
+				return new SpResponseModel(ERROR_VALIDACION, er.getMessage());
 			} catch (Exception er) {
 				connection.rollback();
 				er.printStackTrace();
-				return new SpResponseModel(500, er.getMessage());
+				return new SpResponseModel(ERROR_VALIDACION, er.getMessage());
 			} finally {
 				connection.setAutoCommit(autoCommitOriginal);
 			}
 		} catch (SQLException er) {
 			er.printStackTrace();
-			return new SpResponseModel(500, er.getMessage());
+			return new SpResponseModel(ERROR_VALIDACION, er.getMessage());
 		} catch (Exception er) {
 			er.printStackTrace();
-			return new SpResponseModel(500, er.getMessage());
+			return new SpResponseModel(ERROR_VALIDACION, er.getMessage());
 		}
 	}
 
@@ -226,10 +236,10 @@ public class CompraController implements java.io.Serializable {
 			return this.insertArticuloCompra(connection, articuloPorCompra);
 		} catch (SQLException er) {
 			er.printStackTrace();
-			return new SpResponseModel(500, er.getMessage());
+			return new SpResponseModel(ERROR_VALIDACION, er.getMessage());
 		} catch (Exception er) {
 			er.printStackTrace();
-			return new SpResponseModel(500, er.getMessage());
+			return new SpResponseModel(ERROR_VALIDACION, er.getMessage());
 		}
 	}
 
@@ -238,10 +248,10 @@ public class CompraController implements java.io.Serializable {
 			return this.sumarExistenciaSucursalCompra(connection, idCompra, idArticulo, cantidad);
 		} catch (SQLException er) {
 			er.printStackTrace();
-			return new SpResponseModel(500, er.getMessage());
+			return new SpResponseModel(ERROR_VALIDACION, er.getMessage());
 		} catch (Exception er) {
 			er.printStackTrace();
-			return new SpResponseModel(500, er.getMessage());
+			return new SpResponseModel(ERROR_VALIDACION, er.getMessage());
 		}
 	}
 
@@ -250,10 +260,10 @@ public class CompraController implements java.io.Serializable {
 			return this.updateCompra(connection, idSucursal, compra);
 		} catch (SQLException er) {
 			er.printStackTrace();
-			return new SpResponseModel(500, er.getMessage());
+			return new SpResponseModel(ERROR_VALIDACION, er.getMessage());
 		} catch (Exception er) {
 			er.printStackTrace();
-			return new SpResponseModel(500, er.getMessage());
+			return new SpResponseModel(ERROR_VALIDACION, er.getMessage());
 		}
 	}
 
@@ -262,16 +272,16 @@ public class CompraController implements java.io.Serializable {
 			return this.updateArticuloCompra(connection, articuloPorCompra);
 		} catch (SQLException er) {
 			er.printStackTrace();
-			return new SpResponseModel(500, er.getMessage());
+			return new SpResponseModel(ERROR_VALIDACION, er.getMessage());
 		} catch (Exception er) {
 			er.printStackTrace();
-			return new SpResponseModel(500, er.getMessage());
+			return new SpResponseModel(ERROR_VALIDACION, er.getMessage());
 		}
 	}
 
 	public SpResponseModel updateCompra(int idSucursal, CompraConDetalle compraConDetalle) {
 		if (compraConDetalle == null || compraConDetalle.getCompra() == null) {
-			return new SpResponseModel(500, "La compra es obligatoria");
+			return new SpResponseModel(ERROR_VALIDACION, "La compra es obligatoria");
 		}
 
 		List<ArticuloPorCompra> articulos = compraConDetalle.getArticulosPorCompra() == null ? Collections.emptyList()
@@ -319,20 +329,20 @@ public class CompraController implements java.io.Serializable {
 			} catch (SQLException er) {
 				connection.rollback();
 				er.printStackTrace();
-				return new SpResponseModel(500, er.getMessage());
+				return new SpResponseModel(ERROR_VALIDACION, er.getMessage());
 			} catch (Exception er) {
 				connection.rollback();
 				er.printStackTrace();
-				return new SpResponseModel(500, er.getMessage());
+				return new SpResponseModel(ERROR_VALIDACION, er.getMessage());
 			} finally {
 				connection.setAutoCommit(autoCommitOriginal);
 			}
 		} catch (SQLException er) {
 			er.printStackTrace();
-			return new SpResponseModel(500, er.getMessage());
+			return new SpResponseModel(ERROR_VALIDACION, er.getMessage());
 		} catch (Exception er) {
 			er.printStackTrace();
-			return new SpResponseModel(500, er.getMessage());
+			return new SpResponseModel(ERROR_VALIDACION, er.getMessage());
 		}
 	}
 
@@ -345,16 +355,95 @@ public class CompraController implements java.io.Serializable {
 			}
 		} catch (SQLException er) {
 			er.printStackTrace();
-			return new SpResponseModel(500, er.getMessage());
+			return new SpResponseModel(ERROR_VALIDACION, er.getMessage());
 		} catch (Exception er) {
 			er.printStackTrace();
-			return new SpResponseModel(500, er.getMessage());
+			return new SpResponseModel(ERROR_VALIDACION, er.getMessage());
 		}
+	}
+
+	private SpResponseModel validarNuevaCompra(int idSucursal, CompraConDetalle compraConDetalle) {
+		if (compraConDetalle == null || compraConDetalle.getCompra() == null) {
+			return new SpResponseModel(ERROR_VALIDACION, "La compra es obligatoria");
+		}
+
+		SpResponseModel validacionCabecera = this.validarCabeceraNuevaCompra(idSucursal, compraConDetalle.getCompra());
+		if (validacionCabecera != null) {
+			return validacionCabecera;
+		}
+
+		List<ArticuloPorCompra> articulos = compraConDetalle.getArticulosPorCompra();
+		if (articulos == null || articulos.isEmpty()) {
+			return new SpResponseModel(ERROR_VALIDACION, "La compra debe contener al menos un artículo");
+		}
+
+		Set<Integer> articulosProcesados = new HashSet<>();
+		double subtotalDetalle = 0;
+		for (ArticuloPorCompra articulo : articulos) {
+			if (articulo == null) {
+				return new SpResponseModel(ERROR_VALIDACION, "El detalle de la compra contiene un artículo inválido");
+			}
+			if (articulo.getIdArticulo() <= 0) {
+				return new SpResponseModel(ERROR_VALIDACION, "El artículo de compra es obligatorio");
+			}
+			if (!articulosProcesados.add(articulo.getIdArticulo())) {
+				return new SpResponseModel(ERROR_VALIDACION, "No se puede registrar el mismo artículo más de una vez");
+			}
+			if (articulo.getCantidad() <= 0) {
+				return new SpResponseModel(ERROR_VALIDACION, "La cantidad de cada artículo debe ser mayor a cero");
+			}
+			if (!Double.isFinite(articulo.getSubtotal()) || articulo.getSubtotal() < 0) {
+				return new SpResponseModel(ERROR_VALIDACION, "El subtotal de cada artículo debe ser válido y no negativo");
+			}
+			subtotalDetalle += articulo.getSubtotal();
+		}
+
+		double tolerancia = TOLERANCIA_IMPORTE * Math.max(1, articulos.size());
+		if (Math.abs(subtotalDetalle - compraConDetalle.getCompra().getSubtotal()) > tolerancia) {
+			return new SpResponseModel(ERROR_VALIDACION,
+					"El subtotal de la compra no coincide con la suma de los artículos");
+		}
+
+		return null;
+	}
+
+	private SpResponseModel validarCabeceraNuevaCompra(int idSucursal, Compra compra) {
+		if (compra == null) {
+			return new SpResponseModel(ERROR_VALIDACION, "La compra es obligatoria");
+		}
+		if (idSucursal <= 0) {
+			return new SpResponseModel(ERROR_VALIDACION, "La sucursal es obligatoria");
+		}
+		if (compra.getIdEmpleado() <= 0) {
+			return new SpResponseModel(ERROR_VALIDACION, "El empleado que recibe la compra es obligatorio");
+		}
+		if (compra.getIdProveedor() <= 0) {
+			return new SpResponseModel(ERROR_VALIDACION, "El proveedor es obligatorio");
+		}
+		if (compra.getFolioFactura() == null || compra.getFolioFactura().isBlank()) {
+			return new SpResponseModel(ERROR_VALIDACION, "El folio de factura es obligatorio");
+		}
+		if (compra.getFolioFactura().trim().length() > 13) {
+			return new SpResponseModel(ERROR_VALIDACION, "El folio de factura no puede exceder 13 caracteres");
+		}
+		if (compra.getFechaFactura() == null) {
+			return new SpResponseModel(ERROR_VALIDACION, "La fecha de factura es obligatoria");
+		}
+		if (compra.getFechaCompra() == null) {
+			return new SpResponseModel(ERROR_VALIDACION, "La fecha de compra es obligatoria");
+		}
+		if (!Double.isFinite(compra.getSubtotal()) || compra.getSubtotal() < 0) {
+			return new SpResponseModel(ERROR_VALIDACION, "El subtotal de la compra debe ser válido y no negativo");
+		}
+		if (!Double.isFinite(compra.getIva()) || compra.getIva() < 0) {
+			return new SpResponseModel(ERROR_VALIDACION, "El IVA de la compra debe ser válido y no negativo");
+		}
+		return null;
 	}
 
 	private SpResponseModel insertCompra(Connection connection, int idSucursal, Compra compra) throws SQLException {
 		if (compra == null) {
-			return new SpResponseModel(500, "La compra es obligatoria");
+			return new SpResponseModel(ERROR_VALIDACION, "La compra es obligatoria");
 		}
 
 		try (CallableStatement stm = connection.prepareCall("CALL insertCompra(?,?,?,?,?,?,?,?,?)")) {
@@ -377,7 +466,7 @@ public class CompraController implements java.io.Serializable {
 	private SpResponseModel insertArticuloCompra(Connection connection, ArticuloPorCompra articuloPorCompra)
 			throws SQLException {
 		if (articuloPorCompra == null) {
-			return new SpResponseModel(500, "El artículo de compra es obligatorio");
+			return new SpResponseModel(ERROR_VALIDACION, "El artículo de compra es obligatorio");
 		}
 
 		try (CallableStatement stm = connection.prepareCall("CALL insertArticuloCompra(?,?,?,?)")) {
@@ -407,7 +496,7 @@ public class CompraController implements java.io.Serializable {
 
 	private SpResponseModel updateCompra(Connection connection, int idSucursal, Compra compra) throws SQLException {
 		if (compra == null) {
-			return new SpResponseModel(500, "La compra es obligatoria");
+			return new SpResponseModel(ERROR_VALIDACION, "La compra es obligatoria");
 		}
 
 		try (CallableStatement stm = connection.prepareCall("CALL updateCompra(?,?,?,?,?,?,?,?,?,?)")) {
@@ -431,7 +520,7 @@ public class CompraController implements java.io.Serializable {
 	private SpResponseModel updateArticuloCompra(Connection connection, ArticuloPorCompra articuloPorCompra)
 			throws SQLException {
 		if (articuloPorCompra == null) {
-			return new SpResponseModel(500, "El artículo de compra es obligatorio");
+			return new SpResponseModel(ERROR_VALIDACION, "El artículo de compra es obligatorio");
 		}
 
 		try (CallableStatement stm = connection.prepareCall("CALL updateArticuloCompra(?,?,?)")) {
@@ -470,11 +559,11 @@ public class CompraController implements java.io.Serializable {
 		if (rset != null && rset.next()) {
 			return new SpResponseModel(rset.getInt("id"), rset.getString("message"));
 		}
-		return new SpResponseModel(500, "Sin respuesta del procedimiento almacenado");
+		return new SpResponseModel(ERROR_VALIDACION, "Sin respuesta del procedimiento almacenado");
 	}
 
 	private boolean isSuccess(SpResponseModel response) {
-		return response != null && response.id() > 0 && response.id() != 500;
+		return response != null && response.id() > 0 && response.id() != ERROR_VALIDACION;
 	}
 
 	private void setNullableInt(CallableStatement stm, int index, int value) throws SQLException {

--- a/src/main/java/com/kathsoft/kathpos/app/view/compras/Fr_DatosCompras.java
+++ b/src/main/java/com/kathsoft/kathpos/app/view/compras/Fr_DatosCompras.java
@@ -9,9 +9,18 @@ import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.math.BigDecimal;
+import java.sql.Date;
 import java.text.ParseException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.swing.AbstractAction;
 import javax.swing.BoxLayout;
@@ -43,8 +52,12 @@ import javax.swing.text.MaskFormatter;
 
 import com.kathsoft.kathpos.app.model.ArticulosPorVentas;
 import com.kathsoft.kathpos.app.model.articulo.ArticuloByCodigo;
+import com.kathsoft.kathpos.app.model.compra.ArticuloPorCompra;
+import com.kathsoft.kathpos.app.model.compra.Compra;
+import com.kathsoft.kathpos.app.model.compra.CompraConDetalle;
 import com.kathsoft.kathpos.app.model.interfaces.IListadoArticulosAcciones;
 import com.kathsoft.kathpos.app.model.viewmodel.JComboboxDataViewModel;
+import com.kathsoft.kathpos.app.model.viewmodel.SpResponseModel;
 import com.kathsoft.kathpos.app.view.shared.Fr_ListaArticulos;
 import com.kathsoft.kathpos.tools.AppContext;
 import com.kathsoft.kathpos.tools.ConstantsConllections;
@@ -58,6 +71,8 @@ public class Fr_DatosCompras extends JFrame implements IListadoArticulosAcciones
 	private static final int COLUMNA_COSTO_UNITARIO = 3;
 	private static final int COLUMNA_SUBTOTAL = 4;
 	private static final double FACTOR_IVA = 1.16;
+	private static final DateTimeFormatter FORMATO_FECHA = DateTimeFormatter.ofPattern("dd/MM/uuuu")
+			.withResolverStyle(ResolverStyle.STRICT);
 	private int idSucursal;
 	private ArticuloByCodigo articuloConsultado;
 	private Map<String, ArticuloByCodigo> articulosPorCodigo;
@@ -423,10 +438,12 @@ public class Fr_DatosCompras extends JFrame implements IListadoArticulosAcciones
 
 		this.btnCancelar = new JButton("Cancelar");
 		this.btnCancelar.setToolTipText("Cerrar form y cancelar operacion");
+		this.btnCancelar.addActionListener(e -> this.dispose());
 		this.panelInferiorBotones.add(this.btnCancelar);
 
 		this.btnGuardarCompra = new JButton("Guardar");
 		this.btnGuardarCompra.setToolTipText("Guardar compra");
+		this.btnGuardarCompra.addActionListener(e -> this.guardarNuevaCompra());
 		this.panelInferiorBotones.add(this.btnGuardarCompra);
 
 	}
@@ -687,6 +704,132 @@ public class Fr_DatosCompras extends JFrame implements IListadoArticulosAcciones
 		this.txfSubTotal.setText(String.format("%.2f", this.subtotalCompra));
 		this.txfIva.setText(String.format("%.2f", this.ivaCompra));
 		this.lblTotalCompra.setText(String.format("$%.2f", totalCompra));
+	}
+
+	private void guardarNuevaCompra() {
+		if (this.tableArticulosListados.isEditing() && this.tableArticulosListados.getCellEditor() != null
+				&& !this.tableArticulosListados.getCellEditor().stopCellEditing()) {
+			JOptionPane.showMessageDialog(this, "No fue posible confirmar la edición de la cantidad del artículo",
+					"Cantidad inválida", JOptionPane.WARNING_MESSAGE);
+			return;
+		}
+
+		try {
+			CompraConDetalle compraConDetalle = this.construirNuevaCompraDesdeFormulario();
+			SpResponseModel respuesta = AppContext.compraController.insertCompra(this.idSucursal, compraConDetalle);
+
+			if (respuesta == null || respuesta.id() <= 0 || respuesta.id() == 500) {
+				String mensaje = respuesta == null ? "No se recibió respuesta al registrar la compra" : respuesta.message();
+				JOptionPane.showMessageDialog(this, mensaje, "No fue posible registrar la compra",
+						JOptionPane.ERROR_MESSAGE);
+				return;
+			}
+
+			this.txfIdCompra.setText(String.valueOf(respuesta.id()));
+			JOptionPane.showMessageDialog(this,
+					respuesta.message() + "\nID de compra: " + respuesta.id(), "Compra registrada",
+					JOptionPane.INFORMATION_MESSAGE);
+			this.dispose();
+		} catch (IllegalArgumentException er) {
+			JOptionPane.showMessageDialog(this, er.getMessage(), "Datos incompletos", JOptionPane.WARNING_MESSAGE);
+		} catch (Exception er) {
+			er.printStackTrace(System.err);
+			JOptionPane.showMessageDialog(this, "Ha ocurrido un error al registrar la compra: " + er.getMessage(),
+					"Error", JOptionPane.ERROR_MESSAGE);
+		}
+	}
+
+	private CompraConDetalle construirNuevaCompraDesdeFormulario() {
+		if (this.idSucursal <= 0) {
+			throw new IllegalArgumentException("No existe una sucursal válida para registrar la compra");
+		}
+
+		String folioFactura = this.txfFolioFactura.getText() == null ? "" : this.txfFolioFactura.getText().trim();
+		if (folioFactura.isEmpty()) {
+			throw new IllegalArgumentException("El folio de factura es obligatorio");
+		}
+		if (folioFactura.length() > 13) {
+			throw new IllegalArgumentException("El folio de factura no puede exceder 13 caracteres");
+		}
+
+		JComboboxDataViewModel proveedor = (JComboboxDataViewModel) this.comboBoxProveedor.getSelectedItem();
+		if (proveedor == null || proveedor.id() <= 0) {
+			throw new IllegalArgumentException("Debe seleccionar un proveedor");
+		}
+
+		JComboboxDataViewModel empleado = (JComboboxDataViewModel) this.comboBoxEmpleado.getSelectedItem();
+		if (empleado == null || empleado.id() <= 0) {
+			throw new IllegalArgumentException("Debe seleccionar el empleado que recibe la compra");
+		}
+
+		Boolean tipoCompra = this.getTipoCompraSeleccionado();
+		if (tipoCompra == null) {
+			throw new IllegalArgumentException("Debe indicar si la compra es de contado o a crédito");
+		}
+
+		Date fechaFactura = this.obtenerFecha(this.formattedTextFieldFechaFactura, "La fecha de factura");
+		Date fechaCompra = this.obtenerFecha(this.formattedTextFieldFechaDeCompra, "La fecha de compra");
+
+		this.recalcularImportesDesdeTabla(false);
+		List<ArticuloPorCompra> articulos = this.construirArticulosPorCompra();
+
+		Compra compra = new Compra.CompraBuilder().idEmpleado(empleado.id()).idProveedor(proveedor.id())
+				.folioFactura(folioFactura).fechaFactura(fechaFactura).fechaCompra(fechaCompra)
+				.tipoCompra(tipoCompra.booleanValue()).subtotal(this.subtotalCompra).iva(this.ivaCompra).activo(true)
+				.build();
+
+		return new CompraConDetalle(compra, articulos);
+	}
+
+	private List<ArticuloPorCompra> construirArticulosPorCompra() {
+		if (this.modelTablaArticulosListados.getRowCount() <= 0) {
+			throw new IllegalArgumentException("Debe agregar al menos un artículo a la compra");
+		}
+
+		List<ArticuloPorCompra> articulos = new ArrayList<>();
+		Set<Integer> idsArticulos = new HashSet<>();
+
+		for (int fila = 0; fila < this.modelTablaArticulosListados.getRowCount(); fila++) {
+			String codigo = String.valueOf(this.modelTablaArticulosListados.getValueAt(fila, COLUMNA_CODIGO)).trim();
+			ArticuloByCodigo articulo = this.articulosPorCodigo.get(codigo);
+			if (articulo == null || articulo.getIdArticulo() <= 0) {
+				throw new IllegalArgumentException("No fue posible identificar el artículo de la fila " + (fila + 1));
+			}
+			if (!idsArticulos.add(articulo.getIdArticulo())) {
+				throw new IllegalArgumentException("El artículo " + codigo + " está repetido en la compra");
+			}
+
+			int cantidad;
+			try {
+				cantidad = this.obtenerCantidadFila(fila);
+			} catch (NumberFormatException er) {
+				throw new IllegalArgumentException("La cantidad del artículo " + codigo + " debe ser un entero mayor a cero");
+			}
+
+			double importeConIva = this.obtenerDoubleFila(fila, COLUMNA_SUBTOTAL);
+			if (!Double.isFinite(importeConIva) || importeConIva < 0) {
+				throw new IllegalArgumentException("El importe del artículo " + codigo + " no es válido");
+			}
+
+			double subtotalDetalle = articulo.isExento() ? importeConIva : importeConIva / FACTOR_IVA;
+			articulos.add(new ArticuloPorCompra.ArticuloPorCompraBuilder().idArticulo(articulo.getIdArticulo())
+					.cantidad(cantidad).subtotal(subtotalDetalle).build());
+		}
+
+		return articulos;
+	}
+
+	private Date obtenerFecha(JFormattedTextField campo, String nombreCampo) {
+		String texto = campo.getText() == null ? "" : campo.getText().trim();
+		if (texto.isEmpty() || texto.indexOf('_') >= 0) {
+			throw new IllegalArgumentException(nombreCampo + " es obligatoria");
+		}
+
+		try {
+			return Date.valueOf(LocalDate.parse(texto, FORMATO_FECHA));
+		} catch (DateTimeParseException er) {
+			throw new IllegalArgumentException(nombreCampo + " debe tener una fecha válida con formato dd/MM/yyyy");
+		}
 	}
 
 	private void limpiarArticuloConsultado() {

--- a/src/test/java/com/kathsoft/kathpos/app/controller/CompraControllerValidationTest.java
+++ b/src/test/java/com/kathsoft/kathpos/app/controller/CompraControllerValidationTest.java
@@ -1,0 +1,81 @@
+package com.kathsoft.kathpos.app.controller;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Date;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.kathsoft.kathpos.app.model.compra.ArticuloPorCompra;
+import com.kathsoft.kathpos.app.model.compra.Compra;
+import com.kathsoft.kathpos.app.model.compra.CompraConDetalle;
+import com.kathsoft.kathpos.app.model.viewmodel.SpResponseModel;
+
+class CompraControllerValidationTest {
+
+	private static final int ID_SUCURSAL = 1;
+
+	@Test
+	void rechazaCompraSinArticulosAntesDePersistir() {
+		CompraController controller = new CompraController();
+		CompraConDetalle compra = new CompraConDetalle(crearCompra("FAC-001", 100.00, 16.00), List.of());
+
+		SpResponseModel respuesta = controller.insertCompra(ID_SUCURSAL, compra);
+
+		assertAll(() -> assertEquals(500, respuesta.id()),
+				() -> assertEquals("La compra debe contener al menos un artículo", respuesta.message()));
+	}
+
+	@Test
+	void rechazaCabeceraConCamposObligatoriosVaciosAntesDePersistir() {
+		CompraController controller = new CompraController();
+		Compra compraInvalida = new Compra.CompraBuilder().idEmpleado(1).idProveedor(1).folioFactura(" ")
+				.fechaFactura(Date.valueOf("2026-08-26")).fechaCompra(Date.valueOf("2026-08-26")).tipoCompra(false)
+				.subtotal(100.00).iva(16.00).build();
+
+		SpResponseModel respuesta = controller.insertCompra(ID_SUCURSAL,
+				new CompraConDetalle(compraInvalida, List.of(crearDetalle(100, 1, 100.00))));
+
+		assertAll(() -> assertEquals(500, respuesta.id()),
+				() -> assertEquals("El folio de factura es obligatorio", respuesta.message()));
+	}
+
+	@Test
+	void rechazaArticuloDuplicadoAntesDePersistir() {
+		CompraController controller = new CompraController();
+		CompraConDetalle compra = new CompraConDetalle(crearCompra("FAC-002", 200.00, 32.00),
+				List.of(crearDetalle(100, 1, 100.00), crearDetalle(100, 1, 100.00)));
+
+		SpResponseModel respuesta = controller.insertCompra(ID_SUCURSAL, compra);
+
+		assertAll(() -> assertEquals(500, respuesta.id()),
+				() -> assertTrue(respuesta.message().contains("mismo artículo")));
+	}
+
+	@Test
+	void rechazaSubtotalQueNoCoincideConDetalle() {
+		CompraController controller = new CompraController();
+		CompraConDetalle compra = new CompraConDetalle(crearCompra("FAC-003", 150.00, 24.00),
+				List.of(crearDetalle(100, 1, 100.00)));
+
+		SpResponseModel respuesta = controller.insertCompra(ID_SUCURSAL, compra);
+
+		assertAll(() -> assertEquals(500, respuesta.id()),
+				() -> assertEquals("El subtotal de la compra no coincide con la suma de los artículos",
+						respuesta.message()));
+	}
+
+	private Compra crearCompra(String folio, double subtotal, double iva) {
+		return new Compra.CompraBuilder().idEmpleado(1).idProveedor(1).folioFactura(folio)
+				.fechaFactura(Date.valueOf("2026-08-26")).fechaCompra(Date.valueOf("2026-08-26")).tipoCompra(false)
+				.subtotal(subtotal).iva(iva).build();
+	}
+
+	private ArticuloPorCompra crearDetalle(int idArticulo, int cantidad, double subtotal) {
+		return new ArticuloPorCompra.ArticuloPorCompraBuilder().idArticulo(idArticulo).cantidad(cantidad)
+				.subtotal(subtotal).build();
+	}
+}


### PR DESCRIPTION
## Resumen

Esta PR integra el flujo funcional para registrar una nueva compra desde `Fr_DatosCompras`, conectando la captura visual con `CompraController` y con los procedimientos almacenados ya existentes para cabecera, detalle y actualización de existencias.

El objetivo es que una compra solo llegue a persistencia cuando la información mínima sea válida y consistente, y que el alta completa se ejecute como una sola operación transaccional.

No se modifica ningún layout ni se redistribuyen componentes de la UI.

---

## Rama origen y destino

```text
Origen: feat/integrate-new-purchase-flow
Destino: dev
```

---

## Flujo implementado

El registro de una nueva compra queda organizado de la siguiente manera:

```text
Fr_DatosCompras
    |
    |-- validar campos obligatorios
    |-- validar tipo de compra
    |-- validar y procesar tabla de artículos
    |-- construir Compra
    |-- construir List<ArticuloPorCompra>
    |-- construir CompraConDetalle
    v
CompraController.insertCompra(idSucursal, CompraConDetalle)
    |
    |-- validar cabecera y detalle
    |-- CALL insertCompra(...)
    |-- por cada artículo:
    |      CALL insertArticuloCompra(...)
    |      CALL sumarExistenciaSucursalCompra(...)
    |
    |-- COMMIT si todo es correcto
    |-- ROLLBACK si falla cualquier operación
```

La asignación definitiva de `id_compra` continúa siendo responsabilidad del `AUTO_INCREMENT` de MySQL. El ID mostrado previamente en el formulario es únicamente informativo.

### Diagrama funcional

El siguiente diagrama resume visualmente el recorrido de una compra desde la captura hasta la confirmación o reversión de la transacción:

```mermaid
flowchart TD
    A[Usuario captura compra en Fr_DatosCompras] --> B[Presiona Guardar]
    B --> C{Validaciones de formulario correctas?}

    C -- No --> C1[Mostrar mensaje y cancelar guardado]
    C -- Sí --> D[Detener edición activa de JTable]

    D --> E[Procesar filas de artículos]
    E --> F[Construir List de ArticuloPorCompra]
    F --> G[Construir Compra]
    G --> H[Construir CompraConDetalle]

    H --> I[CompraController.insertCompra]
    I --> J{Validaciones de negocio correctas?}

    J -- No --> J1[Retornar SpResponseModel de error]
    J -- Sí --> K[Abrir conexión y desactivar autoCommit]

    K --> L[CALL insertCompra]
    L --> M{Cabecera insertada?}
    M -- No --> R[ROLLBACK]
    M -- Sí --> N[Obtener idCompra generado]

    N --> O{Hay artículos pendientes?}
    O -- Sí --> P[CALL insertArticuloCompra]
    P --> Q{Detalle insertado?}
    Q -- No --> R
    Q -- Sí --> S[CALL sumarExistenciaSucursalCompra]
    S --> T{Existencia actualizada?}
    T -- No --> R
    T -- Sí --> O

    O -- No --> U[COMMIT]
    U --> V[Mostrar compra registrada correctamente]
    R --> W[Restaurar estado mediante rollback]
    W --> X[Mostrar error sin dejar datos parciales]
```

Este flujo garantiza que la cabecera, las partidas y las existencias se comporten como una sola unidad transaccional.

---

## 1. Validaciones en `CompraController`

Se endurece `insertCompra(int idSucursal, CompraConDetalle compraConDetalle)` para impedir que información incompleta o inconsistente llegue a los procedimientos almacenados.

Se valida:

- sucursal válida;
- existencia de la cabecera de compra;
- empleado válido;
- proveedor válido;
- folio de factura obligatorio;
- fecha de factura obligatoria;
- fecha de compra obligatoria;
- subtotal no negativo;
- IVA no negativo;
- existencia de al menos una partida;
- artículo válido en cada partida;
- cantidad mayor a cero;
- subtotal de partida no negativo;
- ausencia de artículos duplicados dentro de la misma compra;
- consistencia entre el subtotal de la cabecera y la suma de subtotales del detalle.

Estas comprobaciones ocurren antes de abrir la operación transaccional cuando pueden resolverse completamente desde Java.

Los procedimientos almacenados conservan sus propias validaciones como segunda capa de integridad.

---

## 2. Procesamiento de artículos desde `Fr_DatosCompras`

El botón `Guardar` queda conectado al flujo real de persistencia.

La tabla:

```text
Código
Descripción
Cantidad
Costo Unitario
Subtotal
```

se transforma en una colección de:

```java
List<ArticuloPorCompra>
```

Cada partida obtiene:

```text
idArticulo
cantidad
subtotal
```

El artículo se resuelve a partir del mapa de `ArticuloByCodigo` que ya mantiene el formulario.

También se detiene cualquier edición activa de la tabla antes de procesar el detalle para evitar guardar un valor todavía no confirmado por el editor Swing.

---

## 3. Tratamiento del IVA y subtotal de partidas

El formulario ya trabaja con `costo_unitario` que incluye IVA.

Por ello, el importe visible de una partida no gravada se procesa directamente como subtotal:

```text
subtotalPartida = costoUnitario * cantidad
IVA = 0
```

Para una partida gravada:

```text
importeConIva = costoUnitario * cantidad
subtotalPartida = importeConIva / 1.16
ivaPartida = importeConIva - subtotalPartida
```

De esta forma:

```text
SUM(articulo_x_compra.subtotal) = compras.subtotal
compras.total = compras.subtotal + compras.iva
```

Esto mantiene coherencia con las pruebas de integración existentes del módulo de compras.

---

## 4. Validaciones finales en `Fr_DatosCompras`

Antes de construir `CompraConDetalle`, el formulario valida:

- contexto de sucursal válido;
- folio de factura no vacío;
- longitud máxima permitida del folio;
- fecha de factura completa y válida;
- fecha de compra completa y válida;
- proveedor seleccionado;
- empleado seleccionado;
- selección explícita de tipo de compra;
- existencia de por lo menos un artículo;
- cantidades enteras mayores a cero;
- artículos válidos en cada fila;
- consistencia de importes después de cualquier edición de cantidad.

Las fechas se interpretan estrictamente bajo:

```text
dd/MM/yyyy
```

No se permiten conversiones tolerantes de fechas inválidas.

---

## 5. Tipo de compra: contado y crédito

Se conserva el contrato actualmente definido en el módulo:

```text
Contado -> false
Crédito -> true
```

El formulario exige que una de las dos opciones se encuentre seleccionada antes de permitir el guardado.

El valor se persiste mediante:

```java
Compra.tipoCompra
```

que finalmente se envía al procedimiento:

```sql
CALL insertCompra(..., p_tipo_compra, ...)
```

---

## 6. Transacción de alta

El controlador reutiliza la transacción ya validada por las pruebas de integración del módulo.

Secuencia:

```text
1. connection.setAutoCommit(false)
2. insertCompra
3. insertArticuloCompra para cada partida
4. sumarExistenciaSucursalCompra para cada partida
5. commit
```

Si cualquiera de los procedimientos falla:

```text
rollback
```

Esto evita estados parciales como:

- compra sin artículos;
- artículo registrado sin existencia actualizada;
- actualización parcial de inventario;
- detalle incompleto asociado a una cabecera persistida.

---

## 7. Procedimientos almacenados reutilizados

No se agregan procedimientos nuevos en esta PR porque los procedimientos requeridos ya existen y ya están cubiertos por las pruebas de integración de base de datos.

Se reutilizan:

```sql
CALL insertCompra(?,?,?,?,?,?,?,?,?);
CALL insertArticuloCompra(?,?,?,?);
CALL sumarExistenciaSucursalCompra(?,?,?);
```

La PR no introduce SQL operativo directo desde Java.

---

## 8. Pruebas agregadas

Se agrega:

```text
src/test/java/com/kathsoft/kathpos/app/controller/CompraControllerValidationTest.java
```

Estas pruebas verifican validaciones que deben resolverse antes de depender de MySQL.

Casos cubiertos:

```text
- rechazar una compra sin artículos;
- rechazar un folio vacío;
- rechazar el mismo artículo agregado más de una vez;
- rechazar una compra cuyo subtotal no coincide con la suma de las partidas.
```

Estas pruebas complementan, pero no sustituyen, las pruebas existentes de integración con MySQL/Testcontainers.

### Diagrama de estrategia de pruebas

La validación se divide en dos niveles: pruebas rápidas de reglas previas a persistencia y pruebas de integración reales contra MySQL.

```mermaid
flowchart TD
    A[GitHub Actions / mvn verify] --> B[Pruebas unitarias]
    A --> C[Pruebas de integración]

    B --> B1[CompraControllerValidationTest]
    B1 --> B2[Compra sin artículos]
    B1 --> B3[Folio vacío]
    B1 --> B4[Artículo duplicado]
    B1 --> B5[Subtotal cabecera distinto al detalle]
    B2 --> B6[Debe rechazarse antes de abrir conexión]
    B3 --> B6
    B4 --> B6
    B5 --> B6

    C --> C1[Testcontainers inicia MySQL 8]
    C1 --> C2[Cargar schema.sql]
    C2 --> C3[Cargar procedures_articulos.sql]
    C3 --> C4[Cargar procedures_compras.sql]
    C4 --> C5[Cargar fixtures mínimos]
    C5 --> C6[CompraControllerIT]

    C6 --> D1[Registrar compra completa]
    C6 --> D2[Insertar partidas]
    C6 --> D3[Actualizar existencias]
    C6 --> D4[Validar subtotal IVA y total]
    C6 --> D5[Validar aislamiento por sucursal]
    C6 --> D6[Forzar error en una partida]

    D1 --> E[Verificar estado final en BD]
    D2 --> E
    D3 --> E
    D4 --> E
    D5 --> E
    D6 --> F[Verificar ROLLBACK completo]

    E --> G{Todas las verificaciones pasan?}
    F --> G
    G -- Sí --> H[BUILD SUCCESS]
    G -- No --> I[BUILD FAILURE / PR no debe integrarse]
```

La intención es separar claramente responsabilidades:

- `CompraControllerValidationTest` comprueba reglas determinísticas de negocio sin depender de infraestructura externa;
- `CompraControllerIT` comprueba que controlador, procedimientos almacenados, transacciones, tablas y existencias funcionen juntos;
- GitHub Actions ejecuta ambos niveles mediante `mvn verify` antes de integrar cambios a `dev`.

---

## 9. Pruebas de integración existentes relacionadas

El proyecto ya contiene `CompraControllerIT`, que cubre el flujo real contra MySQL para:

- creación de cabecera;
- creación de partidas;
- actualización de existencias;
- creación de existencia en sucursal cuando corresponde;
- aislamiento de existencias entre sucursales;
- subtotal;
- IVA;
- importe total;
- rollback completo cuando una partida falla.

El workflow:

```text
.github/workflows/database-integration-tests.yml
```

ejecuta:

```bash
./mvnw --batch-mode --no-transfer-progress verify
```

sobre las PR dirigidas a `dev`.

---

## Archivos modificados

```text
src/main/java/com/kathsoft/kathpos/app/controller/CompraController.java
src/main/java/com/kathsoft/kathpos/app/view/compras/Fr_DatosCompras.java
src/test/java/com/kathsoft/kathpos/app/controller/CompraControllerValidationTest.java
```

---

## Commits incluidos

```text
de12cb5 feat(compras): validate complete new purchase flow
d8710a1 feat(compras): wire new purchase persistence from form
bd83fdb test(compras): cover new purchase pre-persistence validation
```

---

## Cambios expresamente fuera de alcance

Esta PR NO incluye:

- modificación de layouts;
- redistribución de componentes Swing;
- creación de nuevos controles visuales;
- edición completa de compras existentes;
- eliminación completa de compras;
- modificaciones a los procedimientos almacenados actuales;
- SQL de negocio directo desde Java;
- registro de pólizas contables;
- flujo definitivo de pagos a proveedor.

---

## Limitación conocida: compras de contado

El esquema contiene:

```text
pago_proveedor
```

con relación a:

```text
id_compra
id_forma_pago
importe
```

Sin embargo, el formulario actual no captura forma de pago y el flujo modular de compras utilizado por esta PR no dispone todavía de un procedimiento específico integrado para registrar el pago al proveedor durante el alta.

Por tanto, en esta PR:

```text
Contado / Crédito
```

queda correctamente validado y persistido en:

```text
compras.tipo_compra
```

pero una compra marcada como `Contado` todavía no genera automáticamente el movimiento correspondiente en `pago_proveedor`.

Ese comportamiento debe implementarse como una etapa posterior, comenzando por el procedimiento almacenado correspondiente antes de integrar cualquier lógica Java, conforme a las reglas arquitectónicas del proyecto.

---

## Criterios de aceptación

La PR debe considerarse válida si:

- [ ] el proyecto compila con Java 21;
- [ ] las pruebas unitarias existentes continúan pasando;
- [ ] `CompraControllerValidationTest` pasa completamente;
- [ ] `CompraControllerIT` pasa contra MySQL/Testcontainers;
- [ ] una compra sin campos obligatorios no puede persistirse;
- [ ] una compra sin artículos no puede persistirse;
- [ ] cantidades inválidas no pueden persistirse;
- [ ] artículos duplicados dentro de una compra son rechazados;
- [ ] contado/crédito debe seleccionarse obligatoriamente;
- [ ] los artículos se registran correctamente en `articulo_x_compra`;
- [ ] las existencias se actualizan únicamente en la sucursal correspondiente;
- [ ] subtotal, IVA y total permanecen consistentes;
- [ ] cualquier error durante el detalle provoca rollback completo;
- [ ] no existen cambios de layout o distribución visual.

---

## Revisión recomendada

Antes de integrar a `dev`, revisar especialmente:

1. cálculo de subtotal por partida para artículos gravados y exentos;
2. consistencia entre subtotal de detalle y cabecera;
3. procesamiento de edición activa en la columna `Cantidad`;
4. resultado de `mvn verify` en GitHub Actions;
5. prueba manual desde `Fr_DatosCompras` con una compra de contado y otra a crédito;
6. incremento real de existencias en la sucursal después del guardado.

La PR se crea como **Draft** hasta completar las validaciones automáticas y la prueba manual del formulario.